### PR TITLE
feat: add cloudflare to plugins installation

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -68,6 +68,7 @@ function install(string $path = '.'): void
         https://github.com/jaymcp/cmb2-field-order/archive/refs/tags/$cmb2_field_order_version.zip \
         jetpack \
         --activate", context: $context);
+    run("wp plugin install cloudflare --activate", context: $context);
 }
 
 function get_github_latest_version(string $url): string {


### PR DESCRIPTION
For me, the existing run("wp plugin install") was crashing due to bad "zip file format" when extracting "cmb2 extension"

I had to duplicate this line and install cloudflare in a seperate function call to make it works and see "cloudflare" folder inside wp-content/plugins after installation script was completed.

Either need to fix the above command and add "cloudflare" after jetpack or keep this duplicated line to isolate cloudflare installation.