### PR TITLE
feat amn 33 breadcrumb for articles

### DIFF
--- a/private/src/styles/pages/article/_header.scss
+++ b/private/src/styles/pages/article/_header.scss
@@ -26,3 +26,57 @@
     padding-left: 60px;
   }
 }
+
+.article-header {
+  .yoast-breadcrumb {
+    padding: 16px 0 10px 24px;
+    color: var(--wp--preset--color--grey-dark);
+    max-width: $container-hg;
+    margin: 0 auto;
+
+    @media (min-width: 1440px) {
+      padding-left: 0;
+    }
+
+    > span:first-of-type {
+      display: flex;
+      align-items: center;
+    }
+
+    span::before {
+      vertical-align: middle;
+    }
+
+    span + span::before {
+      content: '';
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      margin: 0 6px;
+      background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.78132 7.99999L5.48132 4.69999L6.42399 3.75732L10.6667 7.99999L6.42399 12.2427L5.48132 11.3L8.78132 7.99999Z' fill='%23575756'/%3E%3C/svg%3E")
+        no-repeat center;
+      background-size: contain;
+    }
+
+    a {
+      font-size: 13px;
+      font-weight: 300;
+      font-weight: 300;
+      text-decoration: none;
+      color: var(--wp--preset--color--grey-dark);
+
+      &:hover {
+        text-decoration: underline;
+        background-color: transparent;
+      }
+    }
+
+    & .breadcrumb_last {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 13px;
+      font-weight: bold;
+    }
+  }
+}

--- a/wp-content/themes/humanity-theme/patterns/post-content.php
+++ b/wp-content/themes/humanity-theme/patterns/post-content.php
@@ -14,6 +14,11 @@ $category = amnesty_get_a_post_term( get_the_ID() )->slug;
 <section class="wp-block-group article <?php echo $category ?>">
 	<!-- wp:group {"tagName":"header","className":"article-header"} -->
 	<header class="wp-block-group article-header">
+		<?php
+		if ( function_exists('yoast_breadcrumb') ) {
+			yoast_breadcrumb( '<nav class="yoast-breadcrumb">','</nav>' );
+		}
+		?>
 		<!-- wp:pattern {"slug":"amnesty/post-metadata"} /-->
 		<!-- wp:pattern {"slug":"amnesty/featured-image"} /-->
 	</header>


### PR DESCRIPTION
pour tester il faut installer le plugin Yoast SEO sur WordPress puis l'activer.

Il faut ensuite aller dans les Settings du plugin, puis Advanced, BreadCrumb.
Une fois dans la rubrique, chercher "Breadcrumbs for post types" et choisir pour les Articles POST "Types de contenu".

