### PR TITLE
fix: display label for jetpack form inputs

### DIFF
--- a/private/src/styles/base/_jetpack-forms.scss
+++ b/private/src/styles/base/_jetpack-forms.scss
@@ -6,11 +6,6 @@
   .wp-block-jetpack-contact-form {
     padding: 24px;
 
-    .grunion-field-wrap:not(.grunion-field-radio-wrap):not(.grunion-field-checkbox-multiple-wrap)
-      .grunion-field-label {
-      display: none;
-    }
-
     .grunion-field-wrap {
       .grunion-field {
         height: 42px;


### PR DESCRIPTION
@AntoineCAU 
Je veux bien ton avis la dessus
En retirant cette règle css les labels s'affichent bien mais je connais pas la raison de l'ajout initial de la ligne.