### PR TITLE
chore: scripts duplication and replacement country pages

### DIFF
--- a/wp-content/themes/humanity-theme/duplicate-country-pages.php
+++ b/wp-content/themes/humanity-theme/duplicate-country-pages.php
@@ -1,0 +1,82 @@
+<?php
+
+
+if (!defined('WP_CLI') || !WP_CLI) {
+    return;
+}
+
+function duplicate_post($post_id, $suffixe)
+{
+    $post = get_post($post_id);
+    $newPost = [
+        'post_title' => $post->post_title,
+        'post_author' => $post->post_author,
+        'post_content' => $post->post_content,
+        'post_excerpt' => $post->post_excerpt,
+        'post_name' => $post->post_name.$suffixe,
+        'post_status' => 'draft',
+        'post_type' => $post->post_type,
+    ];
+
+    $newPostId = wp_insert_post($newPost, true);
+
+    // copy original taxonomies and metadatas
+    $taxonomies = get_object_taxonomies($post->post_type);
+    if ($taxonomies) {
+        foreach ($taxonomies as $taxonomy) {
+            $post_terms = wp_get_object_terms($post_id, $taxonomy, ['fields' => 'slugs']);
+            wp_set_object_terms($newPostId, $post_terms, $taxonomy, false);
+        }
+    }
+    $postMetas = get_post_meta($post_id);
+    foreach ($postMetas as $metaKey => $metaValues) {
+        foreach ($metaValues as $metaValue) {
+            add_post_meta($newPostId, $metaKey, $metaValue);
+        }
+    }
+}
+
+$duplicate_countries = function ($args, $assoc_args) {
+
+    if (!isset($assoc_args['suffixe'])) {
+        WP_CLI::error("L'option --suffixe est obligatoire ! Exemple : wp duplicate-countries --suffixe=-2025");
+    }
+
+    $suffixe = $assoc_args['suffixe'];
+    WP_CLI::line('Duplication des pages pays');
+
+    $duplicatedCountries = 0;
+    $page = 1;
+    $batch_size = 10;
+
+
+    do {
+        $query = new WP_Query([
+            'post_type' => 'fiche_pays',
+            'post_status' => 'publish',
+            'posts_per_page' => $batch_size,
+            'paged' => $page,
+        ]);
+
+        if (! $query->have_posts()) {
+            break; // On sort si la page est vide
+        }
+
+        foreach ($query->posts as $post) {
+            duplicate_post($post->ID, $suffixe);
+            $duplicatedCountries++;
+        }
+
+        wp_reset_postdata();
+
+        if (function_exists('wp_cache_flush')) {
+            wp_cache_flush();
+        }
+        $page++;
+    } while ($query->have_posts());
+
+    WP_CLI::success("$duplicatedCountries posts ont été copiés");
+
+};
+
+WP_CLI::add_command('duplicate-countries', $duplicate_countries);

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -517,4 +517,8 @@ function verify_turnstile(): bool
     return !empty($body['success']);
 }
 
+if (defined('WP_CLI') && WP_CLI) {
+    require_once __DIR__.'/duplicate-country-pages.php';
+    require_once __DIR__.'/upgrade-country-pages.php';
+}
 // phpcs:enable Squiz.Commenting.InlineComment.WrongStyle,PEAR.Commenting.InlineComment.WrongStyle

--- a/wp-content/themes/humanity-theme/upgrade-country-pages.php
+++ b/wp-content/themes/humanity-theme/upgrade-country-pages.php
@@ -1,0 +1,115 @@
+<?php
+
+function depublish_post($post)
+{
+    $currentStatus = $post->post_status;
+    if ($currentStatus !== 'publish') {
+        return false;
+    }
+
+    $result = wp_update_post([
+        'ID' => $post->ID,
+        'post_status' => 'draft',
+    ], true);
+
+    return !is_wp_error($result);
+}
+
+function update_permalink($post, $newSuffix, $oldSuffix, $removeSuffix = false)
+{
+    $currentPermalink = $post->post_name;
+
+    $newPermalink = $removeSuffix ? str_replace($oldSuffix, '', $currentPermalink) : $currentPermalink . $newSuffix;
+
+    $result = wp_update_post([
+        'ID' => $post->ID,
+        'post_name' => $newPermalink,
+    ], true);
+
+    return !is_wp_error($result);
+}
+
+function publish_post($post)
+{
+    $currentStatus = $post->post_status;
+    if ($currentStatus !== 'draft') {
+        return false;
+    }
+
+    $result = wp_update_post([
+        'ID' => $post->ID,
+        'post_status' => 'publish',
+    ], true);
+
+    return !is_wp_error($result);
+}
+
+$update_countries = function ($args, $assoc_args) {
+    if (!isset($assoc_args['value-to-add'])) {
+        WP_CLI::error("L'option --value-to-add est obligatoire ! Exemple : wp update-countries --value-to-add=-2024");
+    }
+    if (!isset($assoc_args['value-to-remove'])) {
+        WP_CLI::error("L'option --value-to-remove est obligatoire ! Exemple : wp update-countries --value-to-remove=-2025");
+    }
+    $adding = $assoc_args['value-to-add'];
+    $removing = $assoc_args['value-to-remove'];
+
+    WP_CLI::line('Mise à jour des pages pays');
+
+    $depublishedCount = 0;
+    $publishedCount = 0;
+    $batchSize = 20;
+    $page = 1;
+
+    do {
+        $query = new WP_Query([
+            'post_type' => 'fiche_pays',
+            'post_status' => ['publish', 'draft'],
+            'orderby' => 'title',
+            'order' => 'ASC',
+            'posts_per_page' => $batchSize,
+            'paged' => $page,
+        ]);
+
+        if (! $query->have_posts()) {
+            break; // On sort si la page est vide
+        }
+
+        $oldPages = array_filter(
+            $query->posts,
+            static fn ($post) => !str_ends_with($post->post_name, $removing)
+        );
+        $newPages = array_filter(
+            $query->posts,
+            static fn ($post) => str_ends_with($post->post_name, $removing)
+        );
+
+        foreach ($oldPages as $post) {
+            if (depublish_post($post) && update_permalink($post, $adding, $removing, false)) {
+                $depublishedCount++;
+            }
+        }
+        wp_reset_postdata();
+
+        if (function_exists('wp_cache_flush')) {
+            wp_cache_flush();
+        }
+
+        foreach ($newPages as $post) {
+            if (update_permalink($post, $adding, $removing, true) && publish_post($post)) {
+                $publishedCount++;
+            }
+        }
+        wp_reset_postdata();
+
+        if (function_exists('wp_cache_flush')) {
+            wp_cache_flush();
+        }
+        $page++;
+    } while ($query->have_posts());
+
+    WP_CLI::success("$depublishedCount posts ont été dépubliés");
+    WP_CLI::success("$publishedCount posts ont été publiés");
+};
+
+WP_CLI::add_command('update-countries', $update_countries);


### PR DESCRIPTION
To test:
Duplicating posts: 
`wp duplicate-countries --suffixe=-2025` (or whatever value you want to append to the slug)

Replacing old posts by duplicated posts:
`wp update-countries --value-to-add=-2024 --value-to-remove=-2025` (where `value-to-add` is whatever you want to append to old post's slug and `value-to-remove` is the value you used in the duplicating command)