### PR TITLE
fix: replace Turnstile redirect with inline error display

### DIFF
--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -539,7 +539,7 @@ function turnstile_friendly_error(string $error): string
     return match ($error) {
         'missing-input-response' => 'Merci de compléter le widget de vérification avant de soumettre le formulaire.',
         'invalid-input-response' => 'La vérification a échoué. Veuillez rafraichir la page et réessayer.',
-		'timeout-or-duplicate' => 'La session de vérification a expiré ou a déjà été utilisée. Veuillez rafraîchir la page et réessayer.',
+        'timeout-or-duplicate' => 'La session de vérification a expiré ou a déjà été utilisée. Veuillez rafraîchir la page et réessayer.',
         'bad-request' => 'La requête de vérification est invalide. Veuillez réessayer.',
         'internal-error' => 'Le service de vérification est temporairement indisponible. Veuillez réessayer dans quelques instants.',
         'missing-input-secret', 'invalid-input-secret', 'invalid-widget-id', 'invalid-parsed-secret' => 'Une erreur de configuration est survenue. Veuillez contacter le support.',

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -538,7 +538,8 @@ function turnstile_friendly_error(string $error): string
 {
     return match ($error) {
         'missing-input-response' => 'Merci de compléter le widget de vérification avant de soumettre le formulaire.',
-        'invalid-input-response', 'timeout-or-duplicate' => 'La session de vérification a expiré ou a déjà été utilisée. Veuillez rafraîchir la page et réessayer.',
+        'invalid-input-response' => 'La vérification a échoué. Veuillez rafraichir la page et réessayer.',
+		'timeout-or-duplicate' => 'La session de vérification a expiré ou a déjà été utilisée. Veuillez rafraîchir la page et réessayer.',
         'bad-request' => 'La requête de vérification est invalide. Veuillez réessayer.',
         'internal-error' => 'Le service de vérification est temporairement indisponible. Veuillez réessayer dans quelques instants.',
         'missing-input-secret', 'invalid-input-secret', 'invalid-widget-id', 'invalid-parsed-secret' => 'Une erreur de configuration est survenue. Veuillez contacter le support.',

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -538,7 +538,7 @@ function turnstile_friendly_error(string $error): string
 {
     return match ($error) {
         'missing-input-response' => 'Merci de compléter le widget de vérification avant de soumettre le formulaire.',
-        'invalid-input-response' => 'La vérification a échoué. Veuillez rafraichir la page et réessayer.',
+        'invalid-input-response' => 'La vérification a échoué. Veuillez rafraîchir la page et réessayer.',
         'timeout-or-duplicate' => 'La session de vérification a expiré ou a déjà été utilisée. Veuillez rafraîchir la page et réessayer.',
         'bad-request' => 'La requête de vérification est invalide. Veuillez réessayer.',
         'internal-error' => 'Le service de vérification est temporairement indisponible. Veuillez réessayer dans quelques instants.',

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -99,11 +99,8 @@ function amnesty_handle_petition_signature(): void
     if (isset($_POST['sign_petition']) && isset($_POST['user_email']) && isset($_POST['petition_id'])) {
         $turnstile_error = verify_turnstile();
         if ($turnstile_error !== null) {
-            wp_safe_redirect(add_query_arg([
-                'signature_status' => 'turnstile_failed',
-                'turnstile_error'  => urlencode($turnstile_error),
-            ], wp_get_referer() ?: home_url()));
-            exit;
+			$GLOBALS['petition_turnstile_error_message'] = turnstile_friendly_error($turnstile_error);
+			return;
         }
 
         $petition_id = absint($_POST['petition_id']);

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -99,8 +99,8 @@ function amnesty_handle_petition_signature(): void
     if (isset($_POST['sign_petition']) && isset($_POST['user_email']) && isset($_POST['petition_id'])) {
         $turnstile_error = verify_turnstile();
         if ($turnstile_error !== null) {
-			$GLOBALS['petition_turnstile_error_message'] = turnstile_friendly_error($turnstile_error);
-			return;
+            $GLOBALS['petition_turnstile_error_message'] = turnstile_friendly_error($turnstile_error);
+            return;
         }
 
         $petition_id = absint($_POST['petition_id']);

--- a/wp-content/themes/humanity-theme/partials/urgent-register-form.php
+++ b/wp-content/themes/humanity-theme/partials/urgent-register-form.php
@@ -8,100 +8,87 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sign_urgent_action'])
     if (!verify_turnstile()) {
         die('Turnstile verification failed.');
     } else {
-        foreach ($input as $item) {
-            if (!isset($_POST[esc_attr($item)])) {
-                wp_safe_redirect(home_url($GLOBALS['wp']->request));
-                exit;
-            }
-        }
+		foreach ($input as $item) {
+			if (!isset($_POST[esc_attr($item)])) {
+				wp_safe_redirect(home_url($GLOBALS['wp']->request));
+				exit;
+			}
+		}
 
-        $type = sanitize_text_field($_POST['type'] ?? '');
-        if (! \in_array($type, [ 'Email', 'Sms', 'Militant' ], true)) {
-            wp_safe_redirect(home_url($GLOBALS['wp']->request));
-            exit;
-        }
-    }
+		$type = sanitize_text_field($_POST['type'] ?? '');
+		if (! \in_array($type, [ 'Email', 'Sms', 'Militant' ], true)) {
+			wp_safe_redirect(home_url($GLOBALS['wp']->request));
+			exit;
+		}
 
-    $type = sanitize_text_field($_POST['type'] ?? '');
-    if (!\in_array($type, ['Email', 'Sms', 'Militant'], true)) {
-        wp_safe_redirect(home_url($GLOBALS['wp']->request));
-        exit;
-    }
+		$email = sanitize_email($_POST['email'] ?? '');
+		if (! is_email($email)) {
+			wp_safe_redirect(home_url($GLOBALS['wp']->request));
+			exit;
+		}
 
-    $email = sanitize_email($_POST['email'] ?? '');
-    if (!is_email($email)) {
-        wp_safe_redirect(home_url($GLOBALS['wp']->request));
-        exit;
-    }
+		$local_user = get_local_user($email);
 
-    $local_user = get_local_user($email);
+		if ($local_user) {
+			$user_id = $local_user->id;
+			$action_already_signed = urgent_action_already_signed($user_id, $type);
 
-    if ($local_user) {
-        $user_id = $local_user->id;
-        $action_already_signed = urgent_action_already_signed($user_id, $type);
+			if (! $action_already_signed) {
+				insert_urgent_action(
+					$type,
+					$user_id,
+					wp_date('Y-m-d'),
+					false
+				);
+			}
 
-        if (!$action_already_signed) {
-            insert_urgent_action(
-                $type,
-                $user_id,
-                wp_date('Y-m-d'),
-                false,
-                $thematique ?? null,
-            );
-        }
+			wp_safe_redirect(
+				add_query_arg([
+					'success' => 'true',
+					'gtm_type' => 'action',
+					'gtm_name' => $action_type ?? '',
+				], home_url($GLOBALS['wp']->request))
+			);
+			exit;
+		}
 
-        wp_safe_redirect(
-            add_query_arg([
-                'success' => 'true',
-                'gtm_type' => 'action',
-                'gtm_name' => $action_type ?? '',
-            ], home_url($GLOBALS['wp']->request))
-        );
-        exit;
-    }
+		$civility = sanitize_text_field($_POST['civility'] ?? '');
+		$firstname = sanitize_text_field($_POST['firstname'] ?? '');
+		$lastname = sanitize_text_field($_POST['lastname'] ?? '');
+		$postal_code = sanitize_text_field($_POST['zipcode'] ?? '');
+		$country = sanitize_text_field($_POST['country'] ?? '');
+		$phone = sanitize_text_field($_POST['tel'] ?? '');
 
-    $civility = sanitize_text_field($_POST['civility'] ?? '');
-    $firstname = sanitize_text_field($_POST['firstname'] ?? '');
-    $lastname = sanitize_text_field($_POST['lastname'] ?? '');
-    $postal_code = sanitize_text_field($_POST['zipcode'] ?? '');
-    $country = sanitize_text_field($_POST['country'] ?? '');
-    $phone = sanitize_text_field($_POST['tel'] ?? '');
+		$new_user_id = insert_user($civility, $firstname, $lastname, $email, $country, $postal_code, $phone);
 
-    $new_user_id = insert_user($civility, $firstname, $lastname, $email, $country, $postal_code, $phone);
+		if (! $new_user_id) {
+			exit;
+		}
 
-    if (!$new_user_id) {
-        exit;
-    }
+		insert_urgent_action(
+			$type,
+			(string) $new_user_id,
+			wp_date('Y-m-d'),
+			false
+		);
 
-    insert_urgent_action(
-        $type,
-        (string)$new_user_id,
-        wp_date('Y-m-d'),
-        false,
-        $thematique ?? null,
-    );
-
-    wp_safe_redirect(
-        add_query_arg([
-            'success' => 'true',
-            'gtm_type' => 'action',
-            'gtm_name' => $action_type ?? '',
-        ], home_url($GLOBALS['wp']->request))
-    );
-    exit;
-}
-
-if (!empty($_GET['turnstile_error'])) {
-    $error_message = turnstile_friendly_error(sanitize_text_field(urldecode($_GET['turnstile_error'])));
-    $title = 'Une erreur est survenue';
+		wp_safe_redirect(
+			add_query_arg([
+				'success' => 'true',
+				'gtm_type' => 'action',
+				'gtm_name' => $action_type ?? '',
+			], home_url($GLOBALS['wp']->request))
+		);
+		exit;
+	}
 }
 
 $countries = get_posts(
     [
-        'post_type' => 'fiche_pays',
+        'post_type'      => 'fiche_pays',
         'posts_per_page' => -1,
-        'orderby' => 'title',
-        'order' => 'ASC',
+        'orderby'        => 'title',
+        'order'          => 'ASC',
     ]
 );
 
@@ -109,31 +96,32 @@ $countries = get_posts(
 
 <div class="urgent-register">
 	<div class="urgent-register-header">
-		<?php
-        if (!empty($title)) {
-            echo '<h3>' . esc_html($title) . '</h3>';
-        }
-?>
 		<p>
 			<?php echo esc_attr($text_header ?? ''); ?>
 		</p>
 	</div>
 	<div class="urgent-register-form">
 		<form id="urgent-register" method="post" action="">
-			<input type="hidden" name="thematique" value="<?php echo esc_attr($thematique ?? '') ?>"/>
 			<div class="cf-turnstile" data-sitekey="<?php echo esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
+			<?php if (isset($_GET['success']) && $_GET['success'] === 'true') : ?>
+			<div class="form-mess success">
+				Votre inscription est bien prise en compte.
+			</div>
+			<?php else : ?>
+				<div class="form-mess hidden"></div>
+			<?php endif; ?>
 			<div class="urgent-register-form-input">
 				<?php
-        foreach ($input as $item) :
-            $item_esc = esc_attr($item);
-            $placeholder = 'tel' === $item ? 'Téléphone mobile' : $item
-            ?>
+                foreach ($input as $item) :
+                    $item_esc    = esc_attr($item);
+                    $placeholder = 'tel' === $item ? 'Téléphone mobile' : $item
+                    ?>
 					<label for="<?php echo $item_esc; ?>"></label>
 					<input class="input"
-					       name="<?php echo $item_esc; ?>"
-					       type="<?php echo $item_esc; ?>"
-					       placeholder="<?php echo esc_attr(ucfirst($placeholder)); ?>"
-					       required
+						   name="<?php echo $item_esc; ?>"
+						   type="<?php echo $item_esc; ?>"
+						   placeholder="<?php echo esc_attr(ucfirst($placeholder)); ?>"
+						   required
 					/>
 					<div class="input-error hidden"></div>
 				<?php endforeach; ?>
@@ -143,57 +131,57 @@ $countries = get_posts(
 						<div class="civilities">
 							<label for="civility_m">M.</label>
 							<input type="radio" id="civility_m"
-							       name="civility"
-							       value="M."
-							       checked>
+									name="civility"
+									value="M."
+									checked>
 							<label for="civility_mme">Mme</label>
 							<input type="radio" id="civility_mme"
-							       name="civility"
-							       value="Mme">
+									name="civility"
+									value="Mme" >
 							<label for="civility_other">Autre</label>
 							<input type="radio" id="civility_other"
-							       name="civility"
-							       value="Autre">
+									name="civility"
+									value="Autre" >
 						</div>
 						<div class="input-error-civility hidden"></div>
 					</div>
 					<div class="form-group">
 						<label for="lastname"></label>
 						<input type="text" id="lastname" name="lastname"
-						       placeholder="Nom" required>
+								placeholder="Nom" required>
 						<div class="input-error hidden"></div>
 					</div>
 					<div class="form-group">
 						<label for="firstname"></label>
 						<input type="text" id="firstname" name="firstname"
-						       placeholder="Prénom" required>
+								placeholder="Prénom" required>
 						<div class="input-error hidden"></div>
 					</div>
 					<div class="form-row">
 						<div class="form-group">
 							<label for="zipcode"></label>
 							<input type="text"
-							       id="zipcode"
-							       name="zipcode"
-							       placeholder="Code Postal"
-							       required>
+									id="zipcode"
+									name="zipcode"
+									placeholder="Code Postal"
+									required>
 							<div class="input-error hidden"></div>
 						</div>
 						<div class="form-group country-selection">
 							<select class="country-input " name="country">
 								<option value=""><?php _e('Pays*', 'textdomain'); ?></option>
 								<?php
-                        foreach ($countries as $country) :
-                            $country_name = get_the_title($country->ID);
-                            ?>
+                                foreach ($countries as $country) :
+                                    $country_name = get_the_title($country->ID);
+                                    ?>
 									<option value="<?php echo esc_attr($country_name); ?>"
 										<?php
-                                if (esc_attr($country_name) === 'France') :
-                                    ?>
+                                        if (esc_attr($country_name) === 'France') :
+                                            ?>
 											selected="selected"
-										<?php
-                                endif;
-                            ?>
+											<?php
+                                        endif;
+                                    ?>
 									>
 										<?php echo esc_html(ucwords(strtolower($country_name))); ?>
 									</option>
@@ -201,7 +189,7 @@ $countries = get_posts(
 							</select>
 						</div>
 					</div>
-					<?php if (!in_array('tel', $input ?? [], true)) : ?>
+					<?php if (! in_array('tel', $input ?? [], true)) : ?>
 						<div class="form-group">
 							<label for="tel"></label>
 							<input
@@ -218,36 +206,17 @@ $countries = get_posts(
 					<input type="hidden" name="type" value="<?php echo esc_attr($action_type ?? ''); ?>">
 				</div>
 			</div>
-			<?php
-            if (!empty($error_message)) {
-                aif_include_partial('alert', [
-                    'state' => 'error',
-                    'title' => $title,
-                    'content' => $error_message]);
-
-            };
-?>
 			<div class="urgent-register-form-cta">
 				<button type="submit" name="sign_urgent_action">
 					<?php
-        echo file_get_contents(get_template_directory() . '/assets/images/icon-arrow.svg');
+                    echo file_get_contents(get_template_directory() . '/assets/images/icon-arrow.svg');
 ?>
 					S'inscrire
 				</button>
 			</div>
 		</form>
 		<div class="urgent-action-legend">
-			<p>Les données personnelles collectées sur ce formulaire sont traitées par l’association Amnesty
-				International France (AIF), responsable du traitement. Ces données vont nous permettre de vous envoyer
-				nos propositions d’engagement, qu’elles soient militantes ou financières. Notre politique de
-				confidentialité détaille la manière dont Amnesty International France, en sa qualité de responsable de
-				traitement, traite et protège vos données personnelles collectées conformément aux dispositions de la
-				Loi du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés dite Loi « Informatique et
-				Libertés », et au Règlement européen du 25 mai 2018 sur la protection des données (« RGPD »). Pour toute
-				demande, vous pouvez contacter le service membres et donateurs d’AIF à l’adresse mentionnée ci-dessus,
-				par email smd@amnesty.fr ou par téléphone 01 53 38 65 80. Vous pouvez également introduire une
-				réclamation auprès de la CNIL. Pour plus d’information sur le traitement de vos données personnelles,
-				veuillez consulter notre politique de confidentialité</p>
+			<p>Les données personnelles collectées sur ce formulaire sont traitées par l’association Amnesty International France (AIF), responsable du traitement. Ces données vont nous permettre de vous envoyer nos propositions d’engagement, qu’elles soient militantes ou financières. Notre politique de confidentialité détaille la manière dont Amnesty International France, en sa qualité de responsable de traitement, traite et protège vos données personnelles collectées conformément aux dispositions de la Loi du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés dite Loi « Informatique et Libertés », et au Règlement européen du 25 mai 2018 sur la protection des données (« RGPD »). Pour toute demande, vous pouvez contacter le service membres et donateurs d’AIF à l’adresse mentionnée ci-dessus, par email smd@amnesty.fr ou par téléphone 01 53 38 65 80. Vous pouvez également introduire une réclamation auprès de la CNIL. Pour plus d’information sur le traitement de vos données personnelles, veuillez consulter notre politique de confidentialité</p>
 		</div>
 	</div>
 </div>

--- a/wp-content/themes/humanity-theme/partials/urgent-register-form.php
+++ b/wp-content/themes/humanity-theme/partials/urgent-register-form.php
@@ -8,79 +8,79 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sign_urgent_action'])
     if (!verify_turnstile()) {
         die('Turnstile verification failed.');
     } else {
-		foreach ($input as $item) {
-			if (!isset($_POST[esc_attr($item)])) {
-				wp_safe_redirect(home_url($GLOBALS['wp']->request));
-				exit;
-			}
-		}
+        foreach ($input as $item) {
+            if (!isset($_POST[esc_attr($item)])) {
+                wp_safe_redirect(home_url($GLOBALS['wp']->request));
+                exit;
+            }
+        }
 
-		$type = sanitize_text_field($_POST['type'] ?? '');
-		if (! \in_array($type, [ 'Email', 'Sms', 'Militant' ], true)) {
-			wp_safe_redirect(home_url($GLOBALS['wp']->request));
-			exit;
-		}
+        $type = sanitize_text_field($_POST['type'] ?? '');
+        if (! \in_array($type, [ 'Email', 'Sms', 'Militant' ], true)) {
+            wp_safe_redirect(home_url($GLOBALS['wp']->request));
+            exit;
+        }
 
-		$email = sanitize_email($_POST['email'] ?? '');
-		if (! is_email($email)) {
-			wp_safe_redirect(home_url($GLOBALS['wp']->request));
-			exit;
-		}
+        $email = sanitize_email($_POST['email'] ?? '');
+        if (! is_email($email)) {
+            wp_safe_redirect(home_url($GLOBALS['wp']->request));
+            exit;
+        }
 
-		$local_user = get_local_user($email);
+        $local_user = get_local_user($email);
 
-		if ($local_user) {
-			$user_id = $local_user->id;
-			$action_already_signed = urgent_action_already_signed($user_id, $type);
+        if ($local_user) {
+            $user_id = $local_user->id;
+            $action_already_signed = urgent_action_already_signed($user_id, $type);
 
-			if (! $action_already_signed) {
-				insert_urgent_action(
-					$type,
-					$user_id,
-					wp_date('Y-m-d'),
-					false
-				);
-			}
+            if (! $action_already_signed) {
+                insert_urgent_action(
+                    $type,
+                    $user_id,
+                    wp_date('Y-m-d'),
+                    false
+                );
+            }
 
-			wp_safe_redirect(
-				add_query_arg([
-					'success' => 'true',
-					'gtm_type' => 'action',
-					'gtm_name' => $action_type ?? '',
-				], home_url($GLOBALS['wp']->request))
-			);
-			exit;
-		}
+            wp_safe_redirect(
+                add_query_arg([
+                    'success' => 'true',
+                    'gtm_type' => 'action',
+                    'gtm_name' => $action_type ?? '',
+                ], home_url($GLOBALS['wp']->request))
+            );
+            exit;
+        }
 
-		$civility = sanitize_text_field($_POST['civility'] ?? '');
-		$firstname = sanitize_text_field($_POST['firstname'] ?? '');
-		$lastname = sanitize_text_field($_POST['lastname'] ?? '');
-		$postal_code = sanitize_text_field($_POST['zipcode'] ?? '');
-		$country = sanitize_text_field($_POST['country'] ?? '');
-		$phone = sanitize_text_field($_POST['tel'] ?? '');
+        $civility = sanitize_text_field($_POST['civility'] ?? '');
+        $firstname = sanitize_text_field($_POST['firstname'] ?? '');
+        $lastname = sanitize_text_field($_POST['lastname'] ?? '');
+        $postal_code = sanitize_text_field($_POST['zipcode'] ?? '');
+        $country = sanitize_text_field($_POST['country'] ?? '');
+        $phone = sanitize_text_field($_POST['tel'] ?? '');
 
-		$new_user_id = insert_user($civility, $firstname, $lastname, $email, $country, $postal_code, $phone);
+        $new_user_id = insert_user($civility, $firstname, $lastname, $email, $country, $postal_code, $phone);
 
-		if (! $new_user_id) {
-			exit;
-		}
+        if (! $new_user_id) {
+            exit;
+        }
 
-		insert_urgent_action(
-			$type,
-			(string) $new_user_id,
-			wp_date('Y-m-d'),
-			false
-		);
+        insert_urgent_action(
+            $type,
+            (string) $new_user_id,
+            wp_date('Y-m-d'),
+            false
+        );
 
-		wp_safe_redirect(
-			add_query_arg([
-				'success' => 'true',
-				'gtm_type' => 'action',
-				'gtm_name' => $action_type ?? '',
-			], home_url($GLOBALS['wp']->request))
-		);
-		exit;
-	}
+        wp_safe_redirect(
+            add_query_arg([
+                'success' => 'true',
+                'gtm_type' => 'action',
+                'gtm_name' => $action_type ?? '',
+            ], home_url($GLOBALS['wp']->request))
+        );
+        exit;
+    }
 }
 
 $countries = get_posts(

--- a/wp-content/themes/humanity-theme/partials/urgent-register-form.php
+++ b/wp-content/themes/humanity-theme/partials/urgent-register-form.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 $input = $input ?? [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sign_urgent_action'])) {
-    if (!verify_turnstile()) {
-        die('Turnstile verification failed.');
+    $turnstile_error = verify_turnstile();
+    if ($turnstile_error !== null) {
+        $title = 'Une erreur est survenue';
+        $error_message = turnstile_friendly_error($turnstile_error);
     } else {
         foreach ($input as $item) {
             if (!isset($_POST[esc_attr($item)])) {
@@ -38,7 +40,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sign_urgent_action'])
                     $type,
                     $user_id,
                     wp_date('Y-m-d'),
-                    false
+                    false,
+                    $thematique ?? null
                 );
             }
 
@@ -69,7 +72,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['sign_urgent_action'])
             $type,
             (string) $new_user_id,
             wp_date('Y-m-d'),
-            false
+            false,
+            $thematique ?? null
         );
 
         wp_safe_redirect(
@@ -102,6 +106,15 @@ $countries = get_posts(
 	</div>
 	<div class="urgent-register-form">
 		<form id="urgent-register" method="post" action="">
+			<?php
+            if (!empty($error_message)) {
+                aif_include_partial('alert', [
+                    'state' => 'error',
+                    'title' => $title,
+                    'content' => $error_message]);
+
+            };
+?>
 			<div class="cf-turnstile" data-sitekey="<?php echo esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
 			<?php if (isset($_GET['success']) && $_GET['success'] === 'true') : ?>
 			<div class="form-mess success">
@@ -112,10 +125,10 @@ $countries = get_posts(
 			<?php endif; ?>
 			<div class="urgent-register-form-input">
 				<?php
-                foreach ($input as $item) :
-                    $item_esc    = esc_attr($item);
-                    $placeholder = 'tel' === $item ? 'Téléphone mobile' : $item
-                    ?>
+    foreach ($input as $item) :
+        $item_esc    = esc_attr($item);
+        $placeholder = 'tel' === $item ? 'Téléphone mobile' : $item
+        ?>
 					<label for="<?php echo $item_esc; ?>"></label>
 					<input class="input"
 						   name="<?php echo $item_esc; ?>"
@@ -171,17 +184,17 @@ $countries = get_posts(
 							<select class="country-input " name="country">
 								<option value=""><?php _e('Pays*', 'textdomain'); ?></option>
 								<?php
-                                foreach ($countries as $country) :
-                                    $country_name = get_the_title($country->ID);
-                                    ?>
+                    foreach ($countries as $country) :
+                        $country_name = get_the_title($country->ID);
+                        ?>
 									<option value="<?php echo esc_attr($country_name); ?>"
 										<?php
-                                        if (esc_attr($country_name) === 'France') :
-                                            ?>
+                            if (esc_attr($country_name) === 'France') :
+                                ?>
 											selected="selected"
 											<?php
-                                        endif;
-                                    ?>
+                            endif;
+                        ?>
 									>
 										<?php echo esc_html(ucwords(strtolower($country_name))); ?>
 									</option>

--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -26,8 +26,8 @@ $post_id = get_the_ID();
 
 $civility = $civility ?? 'M.';
 
-$turnstile_error_code = sanitize_text_field(urldecode($_GET['turnstile_error'] ?? ''));
-$turnstile_error_message = $turnstile_error_code ? turnstile_friendly_error($turnstile_error_code) : '';
+$turnstile_error_message = $GLOBALS['petition_turnstile_error_message'] ?? '';
+
 ?>
 
 <aside class="petition-aside" id="petition">

--- a/wp-content/themes/humanity-theme/patterns/footer-content.php
+++ b/wp-content/themes/humanity-theme/patterns/footer-content.php
@@ -11,163 +11,163 @@ $footer_menu_items = amnesty_get_nav_menu_items('footer-navigation');
 $footer_policy_items = amnesty_get_nav_menu_items('footer-legal');
 
 $social_links = [
-	[
-		'name' => 'Facebook',
-		'url' => 'https://www.facebook.com/amnestyfr',
-		'svg' => '/assets/images/icon-facebook.svg',
-	],
-	[
-		'name' => 'Bluesky',
-		'url' => 'https://bsky.app/profile/amnestyfrance.bsky.social',
-		'svg' => '/assets/images/icon-bluesky.svg',
-	],
-	[
-		'name' => 'Mastodon',
-		'url' => 'https://mastodon.social/@amnestyfrance',
-		'svg' => '/assets/images/icon-mastodon.svg',
-	],
-	[
-		'name' => 'YouTube',
-		'url' => 'https://www.youtube.com/user/AmnestyFrance',
-		'svg' => '/assets/images/icon-youtube.svg',
-	],
-	[
-		'name' => 'Instagram',
-		'url' => 'https://www.instagram.com/amnestyfrance/',
-		'svg' => '/assets/images/icon-instagram.svg',
-	],
-	[
-		'name' => 'LinkedIn',
-		'url' => 'https://www.linkedin.com/company/amnesty-international-france',
-		'svg' => '/assets/images/icon-linkedin.svg',
-	],
-	[
-		'name' => 'TikTok',
-		'url' => 'https://www.tiktok.com/@amnestyfrance',
-		'svg' => '/assets/images/icon-tiktok.svg',
-	],
+    [
+        'name' => 'Facebook',
+        'url' => 'https://www.facebook.com/amnestyfr',
+        'svg' => '/assets/images/icon-facebook.svg',
+    ],
+    [
+        'name' => 'Bluesky',
+        'url' => 'https://bsky.app/profile/amnestyfrance.bsky.social',
+        'svg' => '/assets/images/icon-bluesky.svg',
+    ],
+    [
+        'name' => 'Mastodon',
+        'url' => 'https://mastodon.social/@amnestyfrance',
+        'svg' => '/assets/images/icon-mastodon.svg',
+    ],
+    [
+        'name' => 'YouTube',
+        'url' => 'https://www.youtube.com/user/AmnestyFrance',
+        'svg' => '/assets/images/icon-youtube.svg',
+    ],
+    [
+        'name' => 'Instagram',
+        'url' => 'https://www.instagram.com/amnestyfrance/',
+        'svg' => '/assets/images/icon-instagram.svg',
+    ],
+    [
+        'name' => 'LinkedIn',
+        'url' => 'https://www.linkedin.com/company/amnesty-international-france',
+        'svg' => '/assets/images/icon-linkedin.svg',
+    ],
+    [
+        'name' => 'TikTok',
+        'url' => 'https://www.tiktok.com/@amnestyfrance',
+        'svg' => '/assets/images/icon-tiktok.svg',
+    ],
 ];
 
 $action_links = [
-	[
-		'name' => 'J’AGIS',
-		'url' => '/agir-avec-nous/comment-agir/',
-		'svg' => '/assets/images/icon-agir.svg',
-	],
-	[
-		'name' => 'JE DONNE',
-		'url' => 'https://soutenir.amnesty.fr/b?cid=246&lang=fr_FR',
-		'svg' => '/assets/images/icon-health.svg',
-	],
-	[
-		'name' => 'JE M’ENGAGE',
-		'url' => '/agir-avec-nous/agir-pres-de-chez-soi/',
-		'svg' => '/assets/images/icon-megaphone.svg',
-	],
+    [
+        'name' => 'J’AGIS',
+        'url' => '/agir-avec-nous/comment-agir/',
+        'svg' => '/assets/images/icon-agir.svg',
+    ],
+    [
+        'name' => 'JE DONNE',
+        'url' => 'https://soutenir.amnesty.fr/b?cid=246&lang=fr_FR',
+        'svg' => '/assets/images/icon-health.svg',
+    ],
+    [
+        'name' => 'JE M’ENGAGE',
+        'url' => '/agir-avec-nous/agir-pres-de-chez-soi/',
+        'svg' => '/assets/images/icon-megaphone.svg',
+    ],
 ];
 
 $inscription_nl_status = $_GET['inscription__nl__footer'] ?? '';
 $inscription_nl_success = $inscription_nl_status === 'success';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
-	$turnstile_error = verify_turnstile();
-	if ($turnstile_error !== null) {
-		$error_message = turnstile_friendly_error($turnstile_error);
-	} else {
-		$email = sanitize_email($_POST['newsletter-lead'] ?? '');
+    $turnstile_error = verify_turnstile();
+    if ($turnstile_error !== null) {
+        $error_message = turnstile_friendly_error($turnstile_error);
+    } else {
+        $email = sanitize_email($_POST['newsletter-lead'] ?? '');
 
-		$local_user = get_local_user($email);
-		$get_user_sf = get_salesforce_user_with_email($email);
-		$contact_exist_on_salesforce = $get_user_sf['totalSize'] > 0;
+        $local_user = get_local_user($email);
+        $get_user_sf = get_salesforce_user_with_email($email);
+        $contact_exist_on_salesforce = $get_user_sf['totalSize'] > 0;
 
-		if ($local_user !== false) {
-			$data = [
-				'Email' => $local_user->email,
-				'Salutation' => $local_user->civility,
-				'Code_Postal__c' => $local_user->postal_code,
-				'FirstName' => $local_user->firstname,
-				'LastName' => $local_user->lastname,
-				'Pays__c' => $local_user->country,
-				'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-			];
+        if ($local_user !== false) {
+            $data = [
+                'Email' => $local_user->email,
+                'Salutation' => $local_user->civility,
+                'Code_Postal__c' => $local_user->postal_code,
+                'FirstName' => $local_user->firstname,
+                'LastName' => $local_user->lastname,
+                'Pays__c' => $local_user->country,
+                'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+            ];
 
-			if (!$contact_exist_on_salesforce) {
-				post_salesforce_users([
-					...$data,
-					'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
-				]);
-			} else {
-				update_salesforce_users($get_user_sf['records'][0]['Id'], [
-					...$data,
-					'Optout_toute_communication__c' => false,
-				]);
-			}
+            if (!$contact_exist_on_salesforce) {
+                post_salesforce_users([
+                    ...$data,
+                    'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
+                ]);
+            } else {
+                update_salesforce_users($get_user_sf['records'][0]['Id'], [
+                    ...$data,
+                    'Optout_toute_communication__c' => false,
+                ]);
+            }
 
-			wp_redirect(add_query_arg([
-				'inscription__nl__footer' => 'success',
-				'gtm_type' => 'inscription',
-				'gtm_name' => 'newsletter',
-			], home_url()));
-			exit;
-		}
+            wp_redirect(add_query_arg([
+                'inscription__nl__footer' => 'success',
+                'gtm_type' => 'inscription',
+                'gtm_name' => 'newsletter',
+            ], home_url()));
+            exit;
+        }
 
-		if ($contact_exist_on_salesforce) {
-			$sf_user = $get_user_sf['records'][0];
-			if ($local_user === false) {
-				insert_user(
-					$sf_user['Civility__c'] ?? null,
-					$sf_user['FirstName'],
-					$sf_user['LastName'],
-					$sf_user['Email'],
-					$sf_user['Pays__c'] ?? null,
-					$sf_user['Code_Postal__c'] ?? null,
-					$sf_user['MobilePhone'] ?? null
-				);
-			}
-			$data = [
-				...$sf_user,
-				'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-			];
+        if ($contact_exist_on_salesforce) {
+            $sf_user = $get_user_sf['records'][0];
+            if ($local_user === false) {
+                insert_user(
+                    $sf_user['Civility__c'] ?? null,
+                    $sf_user['FirstName'],
+                    $sf_user['LastName'],
+                    $sf_user['Email'],
+                    $sf_user['Pays__c'] ?? null,
+                    $sf_user['Code_Postal__c'] ?? null,
+                    $sf_user['MobilePhone'] ?? null
+                );
+            }
+            $data = [
+                ...$sf_user,
+                'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+            ];
 
-			$user_id = $data['Id'];
-			unset($data['Id']);
-			unset($data['attributes']);
+            $user_id = $data['Id'];
+            unset($data['Id']);
+            unset($data['attributes']);
 
-			update_salesforce_users($user_id, $data);
+            update_salesforce_users($user_id, $data);
 
-			wp_redirect(add_query_arg([
-				'inscription__nl__footer' => 'success',
-				'gtm_type' => 'inscription',
-				'gtm_name' => 'newsletter',
-			], home_url()));
-			exit;
-		}
+            wp_redirect(add_query_arg([
+                'inscription__nl__footer' => 'success',
+                'gtm_type' => 'inscription',
+                'gtm_name' => 'newsletter',
+            ], home_url()));
+            exit;
+        }
 
-		$get_current_sf_lead = get_salesforce_nl_lead($email);
-		$lead_exist_on_sf = $get_current_sf_lead['totalSize'] > 0;
+        $get_current_sf_lead = get_salesforce_nl_lead($email);
+        $lead_exist_on_sf = $get_current_sf_lead['totalSize'] > 0;
 
-		$new_lead = [
-			'Email' => $email,
-			'LastName' => '_aucun_',
-			'Code_Origine__c' => getenv('AIF_SALESFORCE_CODE_ORIGINE__C__WEB'),
-			'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-		];
+        $new_lead = [
+            'Email' => $email,
+            'LastName' => '_aucun_',
+            'Code_Origine__c' => getenv('AIF_SALESFORCE_CODE_ORIGINE__C__WEB'),
+            'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+        ];
 
-		if (false === $lead_exist_on_sf) {
-			register_salesforce_lead($new_lead);
-			wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
-			exit;
-		}
+        if (false === $lead_exist_on_sf) {
+            register_salesforce_lead($new_lead);
+            wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
+            exit;
+        }
 
-		if (!$contact_exist_on_salesforce) {
-			update_salesforce_lead($get_current_sf_lead['records'][0]['Id'], $new_lead);
-			wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
-			exit;
-		}
+        if (!$contact_exist_on_salesforce) {
+            update_salesforce_lead($get_current_sf_lead['records'][0]['Id'], $new_lead);
+            wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
+            exit;
+        }
 
-		wp_redirect('/newsletter');
-		exit;
-	}
+        wp_redirect('/newsletter');
+        exit;
+    }
 }
 
 ?>
@@ -182,7 +182,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
 
 <button class="back-to-top hidden" aria-label="Retour haut de page">
 	<?php
-	echo file_get_contents(get_template_directory() . '/assets/images/icon-simple-arrow.svg'); ?>
+    echo file_get_contents(get_template_directory() . '/assets/images/icon-simple-arrow.svg'); ?>
 </button>
 
 <div class="over-footer">
@@ -205,35 +205,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
 			</div>
 			<div class="social-network-list">
 				<?php
-				foreach ($social_links as $child) : ?>
+                foreach ($social_links as $child) : ?>
 					<div class="social-network-item">
 						<a class="social-network-item-svg" href="<?php
-						echo $child['url']; ?>"
+                        echo $child['url']; ?>"
 						   target="_blank"
 						   rel="noopener noreferrer"
 						   title="<?php
-						   esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
+                           esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
 							<?php
-							echo file_get_contents(get_template_directory() . $child['svg']); ?>
+                            echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						</a>
 					</div>
 				<?php
-				endforeach; ?>
+                endforeach; ?>
 			</div>
 		</div>
 		<div class="over-footer-action">
 			<div class="call-to-action">
 				<?php
-				foreach ($action_links as $child) : ?>
+                foreach ($action_links as $child) : ?>
 					<a href="<?php
-					echo $child['url']; ?>">
+                    echo $child['url']; ?>">
 						<?php
-						echo file_get_contents(get_template_directory() . $child['svg']); ?>
+                        echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						<span><?php
-							echo $child['name']; ?></span>
+                            echo $child['name']; ?></span>
 					</a>
 				<?php
-				endforeach; ?>
+                endforeach; ?>
 			</div>
 		</div>
 	</div>
@@ -241,55 +241,55 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
 
 <div class="main-footer">
 	<?php
-	if (isset($footer_menu_items['top_level'])) : ?>
+    if (isset($footer_menu_items['top_level'])) : ?>
 		<?php
-		foreach ($footer_menu_items['top_level'] as $_id => $item) : ?>
+        foreach ($footer_menu_items['top_level'] as $_id => $item) : ?>
 			<div class="main-footer-item">
 				<h3 class="title"><?php
-					echo esc_html($item->title); ?></h3>
+                    echo esc_html($item->title); ?></h3>
 				<?php
-				if (isset($footer_menu_items['children'][$item->title])) : ?>
+                if (isset($footer_menu_items['children'][$item->title])) : ?>
 					<ul class="list-children">
 						<?php
-						foreach ($footer_menu_items['children'][$item->title] as $child) : ?>
+                        foreach ($footer_menu_items['children'][$item->title] as $child) : ?>
 							<li class="child"><a
 									href="<?php
-									echo esc_url($child->url ?: get_permalink($item->db_id)); ?>"
+                                    echo esc_url($child->url ?: get_permalink($item->db_id)); ?>"
 									data-type="<?php
-									echo esc_attr($child->type); ?>"
+                                    echo esc_attr($child->type); ?>"
 									data-id="<?php
-									echo absint($child->db_id); ?>"><?php
-									echo esc_html($child->title); ?></a>
+                                    echo absint($child->db_id); ?>"><?php
+                                    echo esc_html($child->title); ?></a>
 							</li>
 						<?php
-						endforeach; ?>
+                        endforeach; ?>
 					</ul>
 				<?php
-				endif; ?>
+                endif; ?>
 			</div>
 		<?php
-		endforeach; ?>
+        endforeach; ?>
 	<?php
-	endif; ?>
+    endif; ?>
 </div>
 
 <div class="privacy-footer">
 	<?php
-	if (isset($footer_policy_items['top_level'])) : ?>
+    if (isset($footer_policy_items['top_level'])) : ?>
 		<ul class="list-children">
 			<?php
-			foreach ($footer_policy_items['top_level'] as $_id => $item) : ?>
+            foreach ($footer_policy_items['top_level'] as $_id => $item) : ?>
 				<li class="child"><a
 						href="<?php
-						echo esc_url($item->url ?: get_permalink($item->db_id)); ?>"><?php
-						echo esc_html($item->title); ?></a>
+                        echo esc_url($item->url ?: get_permalink($item->db_id)); ?>"><?php
+                        echo esc_html($item->title); ?></a>
 				</li>
 			<?php
-			endforeach; ?>
+            endforeach; ?>
 			<li class="child">
 				<a class="ot-sdk-show-settings" style="cursor: pointer">Paramètrer les cookies</a>
 			</li>
 		</ul>
 	<?php
-	endif; ?>
+    endif; ?>
 </div>

--- a/wp-content/themes/humanity-theme/patterns/footer-content.php
+++ b/wp-content/themes/humanity-theme/patterns/footer-content.php
@@ -11,176 +11,168 @@ $footer_menu_items = amnesty_get_nav_menu_items('footer-navigation');
 $footer_policy_items = amnesty_get_nav_menu_items('footer-legal');
 
 $social_links = [
-    [
-        'name' => 'Facebook',
-        'url' => 'https://www.facebook.com/amnestyfr',
-        'svg' => '/assets/images/icon-facebook.svg',
-    ],
-    [
-        'name' => 'Bluesky',
-        'url' => 'https://bsky.app/profile/amnestyfrance.bsky.social',
-        'svg' => '/assets/images/icon-bluesky.svg',
-    ],
-    [
-        'name' => 'Mastodon',
-        'url' => 'https://mastodon.social/@amnestyfrance',
-        'svg' => '/assets/images/icon-mastodon.svg',
-    ],
-    [
-        'name' => 'YouTube',
-        'url' => 'https://www.youtube.com/user/AmnestyFrance',
-        'svg' => '/assets/images/icon-youtube.svg',
-    ],
-    [
-        'name' => 'Instagram',
-        'url' => 'https://www.instagram.com/amnestyfrance/',
-        'svg' => '/assets/images/icon-instagram.svg',
-    ],
-    [
-        'name' => 'LinkedIn',
-        'url' => 'https://www.linkedin.com/company/amnesty-international-france',
-        'svg' => '/assets/images/icon-linkedin.svg',
-    ],
-    [
-        'name' => 'TikTok',
-        'url' => 'https://www.tiktok.com/@amnestyfrance',
-        'svg' => '/assets/images/icon-tiktok.svg',
-    ],
+	[
+		'name' => 'Facebook',
+		'url' => 'https://www.facebook.com/amnestyfr',
+		'svg' => '/assets/images/icon-facebook.svg',
+	],
+	[
+		'name' => 'Bluesky',
+		'url' => 'https://bsky.app/profile/amnestyfrance.bsky.social',
+		'svg' => '/assets/images/icon-bluesky.svg',
+	],
+	[
+		'name' => 'Mastodon',
+		'url' => 'https://mastodon.social/@amnestyfrance',
+		'svg' => '/assets/images/icon-mastodon.svg',
+	],
+	[
+		'name' => 'YouTube',
+		'url' => 'https://www.youtube.com/user/AmnestyFrance',
+		'svg' => '/assets/images/icon-youtube.svg',
+	],
+	[
+		'name' => 'Instagram',
+		'url' => 'https://www.instagram.com/amnestyfrance/',
+		'svg' => '/assets/images/icon-instagram.svg',
+	],
+	[
+		'name' => 'LinkedIn',
+		'url' => 'https://www.linkedin.com/company/amnesty-international-france',
+		'svg' => '/assets/images/icon-linkedin.svg',
+	],
+	[
+		'name' => 'TikTok',
+		'url' => 'https://www.tiktok.com/@amnestyfrance',
+		'svg' => '/assets/images/icon-tiktok.svg',
+	],
 ];
 
 $action_links = [
-    [
-        'name' => 'J’AGIS',
-        'url' => '/agir-avec-nous/comment-agir/',
-        'svg' => '/assets/images/icon-agir.svg',
-    ],
-    [
-        'name' => 'JE DONNE',
-        'url' => 'https://soutenir.amnesty.fr/b?cid=246&lang=fr_FR',
-        'svg' => '/assets/images/icon-health.svg',
-    ],
-    [
-        'name' => 'JE M’ENGAGE',
-        'url' => '/agir-avec-nous/agir-pres-de-chez-soi/',
-        'svg' => '/assets/images/icon-megaphone.svg',
-    ],
+	[
+		'name' => 'J’AGIS',
+		'url' => '/agir-avec-nous/comment-agir/',
+		'svg' => '/assets/images/icon-agir.svg',
+	],
+	[
+		'name' => 'JE DONNE',
+		'url' => 'https://soutenir.amnesty.fr/b?cid=246&lang=fr_FR',
+		'svg' => '/assets/images/icon-health.svg',
+	],
+	[
+		'name' => 'JE M’ENGAGE',
+		'url' => '/agir-avec-nous/agir-pres-de-chez-soi/',
+		'svg' => '/assets/images/icon-megaphone.svg',
+	],
 ];
 
 $inscription_nl_status = $_GET['inscription__nl__footer'] ?? '';
 $inscription_nl_success = $inscription_nl_status === 'success';
-$title_error = 'Une erreur est survenue';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
-    $turnstile_error = verify_turnstile();
-    if ($turnstile_error !== null) {
-        $error_message = turnstile_friendly_error($turnstile_error);
-        wp_safe_redirect(add_query_arg('turnstile_error', urlencode($turnstile_error), wp_get_referer() ?: home_url()));
-        exit;
-    }
+	$turnstile_error = verify_turnstile();
+	if ($turnstile_error !== null) {
+		$error_message = turnstile_friendly_error($turnstile_error);
+	} else {
+		$email = sanitize_email($_POST['newsletter-lead'] ?? '');
 
-    $email = sanitize_email($_POST['newsletter-lead'] ?? '');
+		$local_user = get_local_user($email);
+		$get_user_sf = get_salesforce_user_with_email($email);
+		$contact_exist_on_salesforce = $get_user_sf['totalSize'] > 0;
 
-    $local_user = get_local_user($email);
-    $get_user_sf = get_salesforce_user_with_email($email);
-    $contact_exist_on_salesforce = $get_user_sf['totalSize'] > 0;
+		if ($local_user !== false) {
+			$data = [
+				'Email' => $local_user->email,
+				'Salutation' => $local_user->civility,
+				'Code_Postal__c' => $local_user->postal_code,
+				'FirstName' => $local_user->firstname,
+				'LastName' => $local_user->lastname,
+				'Pays__c' => $local_user->country,
+				'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+			];
 
-    if ($local_user !== false) {
-        $data = [
-            'Email' => $local_user->email,
-            'Salutation' => $local_user->civility,
-            'Code_Postal__c' => $local_user->postal_code,
-            'FirstName' => $local_user->firstname,
-            'LastName' => $local_user->lastname,
-            'Pays__c' => $local_user->country,
-            'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-        ];
+			if (!$contact_exist_on_salesforce) {
+				post_salesforce_users([
+					...$data,
+					'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
+				]);
+			} else {
+				update_salesforce_users($get_user_sf['records'][0]['Id'], [
+					...$data,
+					'Optout_toute_communication__c' => false,
+				]);
+			}
 
-        if (!$contact_exist_on_salesforce) {
-            post_salesforce_users([
-                ...$data,
-                'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
-            ]);
-        } else {
-            update_salesforce_users($get_user_sf['records'][0]['Id'], [
-                ...$data,
-                'Optout_toute_communication__c' => false,
-            ]);
-        }
+			wp_redirect(add_query_arg([
+				'inscription__nl__footer' => 'success',
+				'gtm_type' => 'inscription',
+				'gtm_name' => 'newsletter',
+			], home_url()));
+			exit;
+		}
 
-        wp_redirect(add_query_arg([
-            'inscription__nl__footer' => 'success',
-            'gtm_type' => 'inscription',
-            'gtm_name' => 'newsletter',
-        ], home_url()));
-        exit;
-    }
+		if ($contact_exist_on_salesforce) {
+			$sf_user = $get_user_sf['records'][0];
+			if ($local_user === false) {
+				insert_user(
+					$sf_user['Civility__c'] ?? null,
+					$sf_user['FirstName'],
+					$sf_user['LastName'],
+					$sf_user['Email'],
+					$sf_user['Pays__c'] ?? null,
+					$sf_user['Code_Postal__c'] ?? null,
+					$sf_user['MobilePhone'] ?? null
+				);
+			}
+			$data = [
+				...$sf_user,
+				'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+			];
 
-    if ($contact_exist_on_salesforce) {
-        $sf_user = $get_user_sf['records'][0];
-        if ($local_user === false) {
-            insert_user(
-                $sf_user['Civility__c'] ?? null,
-                $sf_user['FirstName'],
-                $sf_user['LastName'],
-                $sf_user['Email'],
-                $sf_user['Pays__c'] ?? null,
-                $sf_user['Code_Postal__c'] ?? null,
-                $sf_user['MobilePhone'] ?? null
-            );
-        }
-        $data = [
-            ...$sf_user,
-            'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-        ];
+			$user_id = $data['Id'];
+			unset($data['Id']);
+			unset($data['attributes']);
 
-        $user_id = $data['Id'];
-        unset($data['Id']);
-        unset($data['attributes']);
+			update_salesforce_users($user_id, $data);
 
-        update_salesforce_users($user_id, $data);
+			wp_redirect(add_query_arg([
+				'inscription__nl__footer' => 'success',
+				'gtm_type' => 'inscription',
+				'gtm_name' => 'newsletter',
+			], home_url()));
+			exit;
+		}
 
-        wp_redirect(add_query_arg([
-            'inscription__nl__footer' => 'success',
-            'gtm_type' => 'inscription',
-            'gtm_name' => 'newsletter',
-        ], home_url()));
-        exit;
-    }
+		$get_current_sf_lead = get_salesforce_nl_lead($email);
+		$lead_exist_on_sf = $get_current_sf_lead['totalSize'] > 0;
 
-    $get_current_sf_lead = get_salesforce_nl_lead($email);
-    $lead_exist_on_sf = $get_current_sf_lead['totalSize'] > 0;
+		$new_lead = [
+			'Email' => $email,
+			'LastName' => '_aucun_',
+			'Code_Origine__c' => getenv('AIF_SALESFORCE_CODE_ORIGINE__C__WEB'),
+			'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+		];
 
-    $new_lead = [
-        'Email' => $email,
-        'LastName' => '_aucun_',
-        'Code_Origine__c' => getenv('AIF_SALESFORCE_CODE_ORIGINE__C__WEB'),
-        'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-    ];
+		if (false === $lead_exist_on_sf) {
+			register_salesforce_lead($new_lead);
+			wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
+			exit;
+		}
 
-    if (false === $lead_exist_on_sf) {
-        register_salesforce_lead($new_lead);
-        wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
-        exit;
-    }
+		if (!$contact_exist_on_salesforce) {
+			update_salesforce_lead($get_current_sf_lead['records'][0]['Id'], $new_lead);
+			wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
+			exit;
+		}
 
-    if (!$contact_exist_on_salesforce) {
-        update_salesforce_lead($get_current_sf_lead['records'][0]['Id'], $new_lead);
-        wp_redirect(add_query_arg('email', urlencode($email), home_url('/newsletter')));
-        exit;
-    }
-
-    wp_redirect('/newsletter');
-    exit;
-}
-
-if (!empty($_GET['turnstile_error'])) {
-    $error_message = turnstile_friendly_error(sanitize_text_field(urldecode($_GET['turnstile_error'])));
+		wp_redirect('/newsletter');
+		exit;
+	}
 }
 
 ?>
 
-<div id="confirmationPopup" class="popup <?php
-echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
+<div id="confirmationPopup" class="popup <?php echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
 	<div class="popup-content">
 		<a href="<?= home_url() ?>" class="close-btn">&times;</a>
 		<h3>Inscription Réussie !</h3>
@@ -190,7 +182,7 @@ echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
 
 <button class="back-to-top hidden" aria-label="Retour haut de page">
 	<?php
-    echo file_get_contents(get_template_directory() . '/assets/images/icon-simple-arrow.svg'); ?>
+	echo file_get_contents(get_template_directory() . '/assets/images/icon-simple-arrow.svg'); ?>
 </button>
 
 <div class="over-footer">
@@ -204,15 +196,6 @@ echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
 					<div class="cf-turnstile"
 					     data-sitekey="<?php echo esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
 					<input type="text" name="newsletter-lead" placeholder="Votre adresse e-mail">
-					<?php
-                    if (!empty($error_message)) {
-                        aif_include_partial('alert', [
-                            'state' => 'error',
-                            'title' => $title_error,
-                            'content' => $error_message]);
-
-                    };
-?>
 					<button class="register-nl" name="sign_lead" disabled>
 						<span class="button-text">OK</span>
 						<span class="spinner hidden"></span>
@@ -222,35 +205,35 @@ echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
 			</div>
 			<div class="social-network-list">
 				<?php
-                foreach ($social_links as $child) : ?>
+				foreach ($social_links as $child) : ?>
 					<div class="social-network-item">
 						<a class="social-network-item-svg" href="<?php
-    echo $child['url']; ?>"
+						echo $child['url']; ?>"
 						   target="_blank"
 						   rel="noopener noreferrer"
 						   title="<?php
-       esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
+						   esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
 							<?php
-        echo file_get_contents(get_template_directory() . $child['svg']); ?>
+							echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						</a>
 					</div>
 				<?php
-                endforeach; ?>
+				endforeach; ?>
 			</div>
 		</div>
 		<div class="over-footer-action">
 			<div class="call-to-action">
 				<?php
-                foreach ($action_links as $child) : ?>
+				foreach ($action_links as $child) : ?>
 					<a href="<?php
-                    echo esc_url($child['url']); ?>">
+					echo $child['url']; ?>">
 						<?php
-                        echo file_get_contents(get_template_directory() . $child['svg']); ?>
+						echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						<span><?php
-                            echo $child['name']; ?></span>
+							echo $child['name']; ?></span>
 					</a>
 				<?php
-                endforeach; ?>
+				endforeach; ?>
 			</div>
 		</div>
 	</div>
@@ -258,55 +241,55 @@ echo $inscription_nl_success ? 'popup-visible' : ''; ?>">
 
 <div class="main-footer">
 	<?php
-    if (isset($footer_menu_items['top_level'])) : ?>
+	if (isset($footer_menu_items['top_level'])) : ?>
 		<?php
-        foreach ($footer_menu_items['top_level'] as $_id => $item) : ?>
+		foreach ($footer_menu_items['top_level'] as $_id => $item) : ?>
 			<div class="main-footer-item">
 				<h3 class="title"><?php
-                    echo esc_html($item->title); ?></h3>
+					echo esc_html($item->title); ?></h3>
 				<?php
-                if (isset($footer_menu_items['children'][$item->title])) : ?>
+				if (isset($footer_menu_items['children'][$item->title])) : ?>
 					<ul class="list-children">
 						<?php
-                        foreach ($footer_menu_items['children'][$item->title] as $child) : ?>
+						foreach ($footer_menu_items['children'][$item->title] as $child) : ?>
 							<li class="child"><a
 									href="<?php
-                                    echo esc_url($child->url ?: get_permalink($item->db_id)); ?>"
+									echo esc_url($child->url ?: get_permalink($item->db_id)); ?>"
 									data-type="<?php
-                                    echo esc_attr($child->type); ?>"
+									echo esc_attr($child->type); ?>"
 									data-id="<?php
-                                    echo absint($child->db_id); ?>"><?php
-                                    echo esc_html($child->title); ?></a>
+									echo absint($child->db_id); ?>"><?php
+									echo esc_html($child->title); ?></a>
 							</li>
 						<?php
-                        endforeach; ?>
+						endforeach; ?>
 					</ul>
 				<?php
-                endif; ?>
+				endif; ?>
 			</div>
 		<?php
-        endforeach; ?>
+		endforeach; ?>
 	<?php
-    endif; ?>
+	endif; ?>
 </div>
 
 <div class="privacy-footer">
 	<?php
-    if (isset($footer_policy_items['top_level'])) : ?>
+	if (isset($footer_policy_items['top_level'])) : ?>
 		<ul class="list-children">
 			<?php
-            foreach ($footer_policy_items['top_level'] as $_id => $item) : ?>
+			foreach ($footer_policy_items['top_level'] as $_id => $item) : ?>
 				<li class="child"><a
 						href="<?php
-                        echo esc_url($item->url ?: get_permalink($item->db_id)); ?>"><?php
-                        echo esc_html($item->title); ?></a>
+						echo esc_url($item->url ?: get_permalink($item->db_id)); ?>"><?php
+						echo esc_html($item->title); ?></a>
 				</li>
 			<?php
-            endforeach; ?>
+			endforeach; ?>
 			<li class="child">
 				<a class="ot-sdk-show-settings" style="cursor: pointer">Paramètrer les cookies</a>
 			</li>
 		</ul>
 	<?php
-    endif; ?>
+	endif; ?>
 </div>

--- a/wp-content/themes/humanity-theme/patterns/footer-content.php
+++ b/wp-content/themes/humanity-theme/patterns/footer-content.php
@@ -72,6 +72,7 @@ $inscription_nl_success = $inscription_nl_status === 'success';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
     $turnstile_error = verify_turnstile();
     if ($turnstile_error !== null) {
+        $title = 'Une erreur est survenue';
         $error_message = turnstile_friendly_error($turnstile_error);
     } else {
         $email = sanitize_email($_POST['newsletter-lead'] ?? '');
@@ -201,6 +202,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
 						<span class="spinner hidden"></span>
 					</button>
 					<div class="nl-error hidden"></div>
+					<?php
+                    if (!empty($error_message)) {
+                        aif_include_partial('alert', [
+                            'state' => 'error',
+                            'title' => $title,
+                            'content' => $error_message]);
+
+                    };
+?>
 				</form>
 			</div>
 			<div class="social-network-list">
@@ -208,13 +218,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
                 foreach ($social_links as $child) : ?>
 					<div class="social-network-item">
 						<a class="social-network-item-svg" href="<?php
-                        echo $child['url']; ?>"
+    echo esc_url($child['url']); ?>"
 						   target="_blank"
 						   rel="noopener noreferrer"
 						   title="<?php
-                           esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
+       esc_attr_e('Follow us on ' . $child['name'], 'amnesty'); ?>">
 							<?php
-                            echo file_get_contents(get_template_directory() . $child['svg']); ?>
+        echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						</a>
 					</div>
 				<?php
@@ -226,7 +236,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['newsletter-lead'])) {
 				<?php
                 foreach ($action_links as $child) : ?>
 					<a href="<?php
-                    echo $child['url']; ?>">
+                    echo esc_url($child['url']); ?>">
 						<?php
                         echo file_get_contents(get_template_directory() . $child['svg']); ?>
 						<span><?php

--- a/wp-content/themes/humanity-theme/patterns/page-nl-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-nl-content.php
@@ -29,6 +29,7 @@ if (!is_admin() && (!defined('REST_REQUEST') || !REST_REQUEST)) {
     if (isset($_POST['sign_newsletter'])) {
         $turnstile_error = verify_turnstile();
         if ($turnstile_error !== null) {
+            $title = 'Une erreur est survenue';
             $error_message = turnstile_friendly_error($turnstile_error);
         } else {
             $email = sanitize_email($_POST['newsletter'] ?? '');
@@ -191,10 +192,18 @@ print esc_attr($class_name ?? ''); ?>">
 					</div>
 				</div>
 				<?php endif; ?>
+				<?php
+                if (!empty($error_message)) {
+                    aif_include_partial('alert', [
+                        'state' => 'error',
+                        'title' => $title,
+                        'content' => $error_message]);
 
+                };
+?>
 				<button class="newsletter-form-cta" type="submit" name="sign_newsletter">
 					<?php
-                    echo file_get_contents(get_template_directory() . '/assets/images/icon-letters.svg'); ?>
+    echo file_get_contents(get_template_directory() . '/assets/images/icon-letters.svg'); ?>
 					S'abonner
 				</button>
 			</form>

--- a/wp-content/themes/humanity-theme/patterns/page-nl-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-nl-content.php
@@ -27,86 +27,86 @@ if (!is_admin() && (!defined('REST_REQUEST') || !REST_REQUEST)) {
     }
 
     if (isset($_POST['sign_newsletter'])) {
-		$turnstile_error = verify_turnstile();
-		if ($turnstile_error !== null) {
-			$error_message = turnstile_friendly_error($turnstile_error);
-		} else {
-			$email = sanitize_email($_POST['newsletter'] ?? '');
-			$civility = sanitize_text_field($_POST['civility'] ?? '');
-			$lastname = sanitize_text_field($_POST['lastname'] ?? '');
-			$firstname = sanitize_text_field($_POST['firstname'] ?? '');
-			$zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
-			$country = sanitize_text_field($_POST['country'] ?? '');
+        $turnstile_error = verify_turnstile();
+        if ($turnstile_error !== null) {
+            $error_message = turnstile_friendly_error($turnstile_error);
+        } else {
+            $email = sanitize_email($_POST['newsletter'] ?? '');
+            $civility = sanitize_text_field($_POST['civility'] ?? '');
+            $lastname = sanitize_text_field($_POST['lastname'] ?? '');
+            $firstname = sanitize_text_field($_POST['firstname'] ?? '');
+            $zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
+            $country = sanitize_text_field($_POST['country'] ?? '');
 
-			$local_user = get_local_user($email);
-			$get_salesforce_user = get_salesforce_user_with_email($email);
-			$is_salesforce_user = is_array($get_salesforce_user) && $get_salesforce_user['totalSize'] > 0;
-	
-			if ($local_user !== false) {
-				$data = [
-					'Email' => $local_user->email,
-					'Salutation' => $local_user->civility,
-					'Code_Postal__c' => $local_user->postal_code,
-					'FirstName' => $local_user->firstname,
-					'LastName' =>  $local_user->lastname,
-					'Pays__c' => $local_user->country,
-					'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-				];
-				if (!$is_salesforce_user) {
-					post_salesforce_users([
-						...$data,
-						'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
-					]);
-				} else {
-					update_salesforce_users($get_salesforce_user['records'][0]['Id'], [
-						...$data,
-						'Optout_toute_communication__c' => false,
-					]);
-				}
-			}
+            $local_user = get_local_user($email);
+            $get_salesforce_user = get_salesforce_user_with_email($email);
+            $is_salesforce_user = is_array($get_salesforce_user) && $get_salesforce_user['totalSize'] > 0;
 
-			if (!$local_user) {
-				if ($is_salesforce_user) {
-					$sf_user = $get_salesforce_user['records'][0];
-					insert_user(
-						$sf_user['Civility__c'] ?? null,
-						$sf_user['FirstName'],
-						$sf_user['LastName'],
-						$sf_user['Email'],
-						$sf_user['Pays__c'] ?? null,
-						$sf_user['Code_Postal__c'] ?? null,
-						$sf_user['MobilePhone'] ?? null
-					);
-				} else {
-					insert_user($civility, $firstname, $lastname, $email, $country, $zipcode, null);
-					post_salesforce_users(
-						[
-							'Salutation' => $civility,
-							'FirstName' => $firstname,
-							'LastName' => $lastname,
-							'Email' => $email,
-							'Code_Postal__c' => $zipcode,
-							'Pays__c' => $country,
-							'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-						]
-					);
-				}
-			}
+            if ($local_user !== false) {
+                $data = [
+                    'Email' => $local_user->email,
+                    'Salutation' => $local_user->civility,
+                    'Code_Postal__c' => $local_user->postal_code,
+                    'FirstName' => $local_user->firstname,
+                    'LastName' =>  $local_user->lastname,
+                    'Pays__c' => $local_user->country,
+                    'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+                ];
+                if (!$is_salesforce_user) {
+                    post_salesforce_users([
+                        ...$data,
+                        'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
+                    ]);
+                } else {
+                    update_salesforce_users($get_salesforce_user['records'][0]['Id'], [
+                        ...$data,
+                        'Optout_toute_communication__c' => false,
+                    ]);
+                }
+            }
 
-			$lead_on_sf = get_salesforce_nl_lead($email);
+            if (!$local_user) {
+                if ($is_salesforce_user) {
+                    $sf_user = $get_salesforce_user['records'][0];
+                    insert_user(
+                        $sf_user['Civility__c'] ?? null,
+                        $sf_user['FirstName'],
+                        $sf_user['LastName'],
+                        $sf_user['Email'],
+                        $sf_user['Pays__c'] ?? null,
+                        $sf_user['Code_Postal__c'] ?? null,
+                        $sf_user['MobilePhone'] ?? null
+                    );
+                } else {
+                    insert_user($civility, $firstname, $lastname, $email, $country, $zipcode, null);
+                    post_salesforce_users(
+                        [
+                            'Salutation' => $civility,
+                            'FirstName' => $firstname,
+                            'LastName' => $lastname,
+                            'Email' => $email,
+                            'Code_Postal__c' => $zipcode,
+                            'Pays__c' => $country,
+                            'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+                        ]
+                    );
+                }
+            }
 
-			if (is_array($lead_on_sf) && $lead_on_sf['totalSize'] > 0) {
-				deleting_lead_on_salesforce($lead_on_sf['records'][0]['Id']);
-			}
+            $lead_on_sf = get_salesforce_nl_lead($email);
 
-			wp_redirect(add_query_arg([
-				'email' => urlencode($email),
-				'inscription__nl' => 'success',
-				'gtm_type' => 'inscription',
-				'gtm_name' => 'newsletter',
-			], home_url('/newsletter')));
-			exit;
-		}
+            if (is_array($lead_on_sf) && $lead_on_sf['totalSize'] > 0) {
+                deleting_lead_on_salesforce($lead_on_sf['records'][0]['Id']);
+            }
+
+            wp_redirect(add_query_arg([
+                'email' => urlencode($email),
+                'inscription__nl' => 'success',
+                'gtm_type' => 'inscription',
+                'gtm_name' => 'newsletter',
+            ], home_url('/newsletter')));
+            exit;
+        }
 
     }
 }

--- a/wp-content/themes/humanity-theme/patterns/page-nl-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-nl-content.php
@@ -13,7 +13,7 @@ $inscription_nl_status = '';
 $inscription_nl_success = false;
 $local_user = false;
 $is_salesforce_user = false;
-$title_error = 'Une erreur est survenue';
+
 if (!is_admin() && (!defined('REST_REQUEST') || !REST_REQUEST)) {
 
     $email_provided = $_GET['email'] ?? '';
@@ -27,92 +27,87 @@ if (!is_admin() && (!defined('REST_REQUEST') || !REST_REQUEST)) {
     }
 
     if (isset($_POST['sign_newsletter'])) {
-        $turnstile_error = verify_turnstile();
-        if ($turnstile_error !== null) {
-            $error_message = turnstile_friendly_error($turnstile_error);
-            wp_safe_redirect(add_query_arg('turnstile_error', urlencode($turnstile_error), wp_get_referer() ?: home_url()));
-            exit;
-        }
+		$turnstile_error = verify_turnstile();
+		if ($turnstile_error !== null) {
+			$error_message = turnstile_friendly_error($turnstile_error);
+		} else {
+			$email = sanitize_email($_POST['newsletter'] ?? '');
+			$civility = sanitize_text_field($_POST['civility'] ?? '');
+			$lastname = sanitize_text_field($_POST['lastname'] ?? '');
+			$firstname = sanitize_text_field($_POST['firstname'] ?? '');
+			$zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
+			$country = sanitize_text_field($_POST['country'] ?? '');
 
-        $email = sanitize_email($_POST['newsletter'] ?? '');
-        $civility = sanitize_text_field($_POST['civility'] ?? '');
-        $lastname = sanitize_text_field($_POST['lastname'] ?? '');
-        $firstname = sanitize_text_field($_POST['firstname'] ?? '');
-        $zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
-        $country = sanitize_text_field($_POST['country'] ?? '');
+			$local_user = get_local_user($email);
+			$get_salesforce_user = get_salesforce_user_with_email($email);
+			$is_salesforce_user = is_array($get_salesforce_user) && $get_salesforce_user['totalSize'] > 0;
+	
+			if ($local_user !== false) {
+				$data = [
+					'Email' => $local_user->email,
+					'Salutation' => $local_user->civility,
+					'Code_Postal__c' => $local_user->postal_code,
+					'FirstName' => $local_user->firstname,
+					'LastName' =>  $local_user->lastname,
+					'Pays__c' => $local_user->country,
+					'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+				];
+				if (!$is_salesforce_user) {
+					post_salesforce_users([
+						...$data,
+						'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
+					]);
+				} else {
+					update_salesforce_users($get_salesforce_user['records'][0]['Id'], [
+						...$data,
+						'Optout_toute_communication__c' => false,
+					]);
+				}
+			}
 
-        $local_user = get_local_user($email);
-        $get_salesforce_user = get_salesforce_user_with_email($email);
-        $is_salesforce_user = is_array($get_salesforce_user) && $get_salesforce_user['totalSize'] > 0;
+			if (!$local_user) {
+				if ($is_salesforce_user) {
+					$sf_user = $get_salesforce_user['records'][0];
+					insert_user(
+						$sf_user['Civility__c'] ?? null,
+						$sf_user['FirstName'],
+						$sf_user['LastName'],
+						$sf_user['Email'],
+						$sf_user['Pays__c'] ?? null,
+						$sf_user['Code_Postal__c'] ?? null,
+						$sf_user['MobilePhone'] ?? null
+					);
+				} else {
+					insert_user($civility, $firstname, $lastname, $email, $country, $zipcode, null);
+					post_salesforce_users(
+						[
+							'Salutation' => $civility,
+							'FirstName' => $firstname,
+							'LastName' => $lastname,
+							'Email' => $email,
+							'Code_Postal__c' => $zipcode,
+							'Pays__c' => $country,
+							'Optin_Actionaute_Newsletter_mensuelle__c' => true,
+						]
+					);
+				}
+			}
 
-        if ($local_user !== false) {
-            $data = [
-                'Email' => $local_user->email,
-                'Salutation' => $local_user->civility,
-                'Code_Postal__c' => $local_user->postal_code,
-                'FirstName' => $local_user->firstname,
-                'LastName' =>  $local_user->lastname,
-                'Pays__c' => $local_user->country,
-                'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-            ];
-            if (!$is_salesforce_user) {
-                post_salesforce_users([
-                    ...$data,
-                    'Origine__c' => getenv('AIF_SALESFORCE_ORIGINE__C'),
-                ]);
-            } else {
-                update_salesforce_users($get_salesforce_user['records'][0]['Id'], [
-                    ...$data,
-                    'Optout_toute_communication__c' => false,
-                ]);
-            }
-        }
+			$lead_on_sf = get_salesforce_nl_lead($email);
 
-        if (!$local_user) {
-            if ($is_salesforce_user) {
-                $sf_user = $get_salesforce_user['records'][0];
-                insert_user(
-                    $sf_user['Civility__c'] ?? null,
-                    $sf_user['FirstName'],
-                    $sf_user['LastName'],
-                    $sf_user['Email'],
-                    $sf_user['Pays__c'] ?? null,
-                    $sf_user['Code_Postal__c'] ?? null,
-                    $sf_user['MobilePhone'] ?? null
-                );
-            } else {
-                insert_user($civility, $firstname, $lastname, $email, $country, $zipcode, null);
-                post_salesforce_users(
-                    [
-                        'Salutation' => $civility,
-                        'FirstName' => $firstname,
-                        'LastName' => $lastname,
-                        'Email' => $email,
-                        'Code_Postal__c' => $zipcode,
-                        'Pays__c' => $country,
-                        'Optin_Actionaute_Newsletter_mensuelle__c' => true,
-                    ]
-                );
-            }
-        }
+			if (is_array($lead_on_sf) && $lead_on_sf['totalSize'] > 0) {
+				deleting_lead_on_salesforce($lead_on_sf['records'][0]['Id']);
+			}
 
-        $lead_on_sf = get_salesforce_nl_lead($email);
+			wp_redirect(add_query_arg([
+				'email' => urlencode($email),
+				'inscription__nl' => 'success',
+				'gtm_type' => 'inscription',
+				'gtm_name' => 'newsletter',
+			], home_url('/newsletter')));
+			exit;
+		}
 
-        if (is_array($lead_on_sf) && $lead_on_sf['totalSize'] > 0) {
-            deleting_lead_on_salesforce($lead_on_sf['records'][0]['Id']);
-        }
-
-        wp_redirect(add_query_arg([
-            'email' => urlencode($email),
-            'inscription__nl' => 'success',
-            'gtm_type' => 'inscription',
-            'gtm_name' => 'newsletter',
-        ], home_url('/newsletter')));
-        exit;
-    }
-
-    if (!empty($_GET['turnstile_error'])) {
-        $error_message = turnstile_friendly_error(sanitize_text_field(urldecode($_GET['turnstile_error'])));
     }
 }
 ?>
@@ -196,18 +191,10 @@ print esc_attr($class_name ?? ''); ?>">
 					</div>
 				</div>
 				<?php endif; ?>
-				<?php
-                if (!empty($error_message)) {
-                    aif_include_partial('alert', [
-                        'state' => 'error',
-                        'title' => $title_error,
-                        'content' => $error_message]);
 
-                };
-?>
 				<button class="newsletter-form-cta" type="submit" name="sign_newsletter">
 					<?php
-    echo file_get_contents(get_template_directory() . '/assets/images/icon-letters.svg'); ?>
+                    echo file_get_contents(get_template_directory() . '/assets/images/icon-letters.svg'); ?>
 					S'abonner
 				</button>
 			</form>


### PR DESCRIPTION
On Turnstile failure, forms were redirecting with a ?turnstile_error= query param then reading it back on the next GET. This caused form data loss and unnecessary round-trips. Forms now display the error inline, consistent with page-connectez-vous.php.

Affected: urgent-register-form, page-nl-content, footer-content, petitions (via $GLOBALS to pass the error to aside-petition-sticky).