### PR TITLE
fix(deploy): run schema update on remote host

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -38,10 +38,4 @@ jobs:
         run: ssh prod 'source ~/.bash_profile && cd github && bash livraison-prod.sh'
 
       - name: Update schema
-        env:
-          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
-          SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
-          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
-        run: |
-          cd var/www/website 
-          wp update-db-schema
+        run: ssh prod 'cd var/www/website && wp update-db-schema'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -30,6 +30,6 @@ jobs:
           SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
           SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
       - name: Deploy
-        run: ssh staging '~/deploy.sh'
+        run: ssh staging '$HOME/deploy.sh'
       - name: Update schema
         run: ssh staging 'cd var/www/website && wp update-db-schema'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,10 +32,4 @@ jobs:
       - name: Deploy
         run: ssh staging '~/deploy.sh'
       - name: Update schema
-        env:
-          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
-          SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
-          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
-        run: |
-          cd var/www/website 
-          wp update-db-schema
+        run: ssh staging 'cd var/www/website && wp update-db-schema'


### PR DESCRIPTION
## Why

- The deploy workflow ran `wp update-db-schema` on the GitHub runner after the remote deployment finished.
- The runner does not have the deployed website path, so the job failed with `cd: var/www/website: No such file or directory`.

## What changed

- Execute the release schema update through the configured `staging` SSH host.
- Execute the production schema update through the configured `prod` SSH host.
- Remove unused staging SSH environment variables from the schema update steps.

## Checks

- `git diff --check`