### PR TITLE
fix(deploy): use document root for schema update

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Deploy
         run: ssh staging '$HOME/deploy.sh'
       - name: Update schema
-        run: ssh staging 'cd var/www/website && wp update-db-schema'
+        run: ssh staging 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT" && wp update-db-schema'


### PR DESCRIPTION
## Why

- The release deploy now reaches the schema update step, but the hardcoded `var/www/website` path does not exist on the staging host.
- The staging deployment already exposes the correct WordPress path through `DOCUMENT_ROOT` in `~/initenv.sh`.
- Run https://github.com/Amnesty-International-France/website/actions/runs/26818211008/job/79065377013 failed with `cd: var/www/website: No such file or directory`.

## What changed

- Source `~/initenv.sh` in the remote schema update step.
- Run `wp update-db-schema` from `DOCUMENT_ROOT` instead of the hardcoded relative path.

## Checks

- `actionlint .github/workflows/deploy-release.yml`
- `ssh amnesty-preprod 'source $HOME/initenv.sh && printf "DOCUMENT_ROOT=%s\\n" "$DOCUMENT_ROOT" && test -d "$DOCUMENT_ROOT" && cd "$DOCUMENT_ROOT" && wp --version && wp help update-db-schema >/dev/null && printf "update-db-schema command: ok\\n"'