### PR TITLE
fix(theme): use supported wp cli logger

### DIFF
--- a/wp-content/themes/humanity-theme/includes/urgent-action/tables.php
+++ b/wp-content/themes/humanity-theme/includes/urgent-action/tables.php
@@ -47,7 +47,7 @@ function aif_update_schema_action_urgent_tables()
         update_option('current-aif-action-urgente-version', NEW_AU_TABLE_VERSION);
         WP_CLI::success('Schéma mis à jour vers la version '. NEW_AU_TABLE_VERSION);
     } else {
-        WP_CLI::info('La table est déjà à la version '. NEW_AU_TABLE_VERSION);
+        WP_CLI::log('La table est déjà à la version '. NEW_AU_TABLE_VERSION);
     }
 }
 


### PR DESCRIPTION
## Why

- The release deployment now reaches `wp update-db-schema`, but WP-CLI fails because `WP_CLI::info()` is not available in the server WP-CLI version.
- The failure happens when the urgent action table is already at the expected schema version.
- Run https://github.com/Amnesty-International-France/website/actions/runs/26818757137/job/79067308439 failed with `Call to undefined method WP_CLI::info()`.

## What changed

- Replace `WP_CLI::info()` with `WP_CLI::log()` in the urgent action schema update command.
- Keep the existing `WP_CLI::success()` output unchanged for the migration path.

## Checks

- `php -l wp-content/themes/humanity-theme/includes/urgent-action/tables.php`
- `rg -n "WP_CLI::info" wp-content/themes wp-content/plugins/prismic-migration`