### PR TITLE
Feat/user progress persistence#maint 200

### DIFF
--- a/private/src/scripts/App.js
+++ b/private/src/scripts/App.js
@@ -32,7 +32,7 @@ import enhanceJetpackFormPlaceholders from './modules/jetpack-form-fix';
 import { calculator, hoverDonationMenu } from './modules/donation-calculator';
 import petitionShareFeedback from './modules/social-network-clicked';
 import petitionDonateFeedback from './modules/donate-clicked';
-import { toggleFullFormPetition, submitCodeOrigine, initTunnelClhForm } from './modules/petition-form';
+import { toggleFullFormPetition, submitCodeOrigine, initTunnelClhForm, getPetitionIdForCLH, stepperTunnelClh } from './modules/petition-form';
 import { closeUrgentBanner } from './modules/urgent-banner';
 import initJetpackForm from './modules/Form/jetpack-forms';
 import edhFilters from './modules/search-filters-edh';
@@ -101,6 +101,8 @@ const App = () => {
   GoPetitionsForm();
   closeAlertBanner();
   Countdown();
+  getPetitionIdForCLH();
+  stepperTunnelClh();
 
   fluidText(document.getElementsByClassName('article-shareTitle'), 0.9);
 

--- a/private/src/scripts/modules/petition-form.js
+++ b/private/src/scripts/modules/petition-form.js
@@ -85,34 +85,25 @@ export const initTunnelClhForm = () => {
 
 const getSignedPetitionIds = () => {
   try {
-    return JSON.parse(localStorage.getItem('signedPetition') ?? '[]');
+    const parsed = JSON.parse(localStorage.getItem('signedPetition') ?? '[]');
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
 };
 
 export const getPetitionIdForCLH = () => {
-  const button = document.getElementById('petition-clh');
+  const cookieMatch = document.cookie.match(/(?:^|; )clh_signed_petitions=([^;]*)/);
+  if (!cookieMatch) return;
 
-  if (!button) return;
-
-  const currentPetitionId = String(button.dataset.petitionId);
-
-  if (!currentPetitionId) return;
-
-  const signForm = button.closest('form');
-
-  if (!signForm) return;
-
-  signForm.addEventListener('submit', () => {
-    const stored = getSignedPetitionIds();
-    const updated = [...new Set([...stored.map(String), currentPetitionId])];
-    localStorage.setItem('signedPetition', JSON.stringify(updated));
-
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 30);
-    document.cookie = `clh_signed_petitions=${encodeURIComponent(JSON.stringify(updated))};expires=${expires.toUTCString()};path=/;SameSite=Strict`;
-  });
+  try {
+    const cookieIds = JSON.parse(decodeURIComponent(cookieMatch[1]));
+    if (Array.isArray(cookieIds)) {
+      localStorage.setItem('signedPetition', JSON.stringify(cookieIds.map(String)));
+    }
+  } catch {
+    // cookie malformé, on ignore
+  }
 };
 
 export const stepperTunnelClh = () => {

--- a/private/src/scripts/modules/petition-form.js
+++ b/private/src/scripts/modules/petition-form.js
@@ -83,6 +83,56 @@ export const initTunnelClhForm = () => {
   });
 };
 
+const getSignedPetitionIds = () => {
+  try {
+    return JSON.parse(localStorage.getItem('signedPetition') ?? '[]');
+  } catch {
+    return [];
+  }
+};
+
+export const getPetitionIdForCLH = () => {
+  const button = document.getElementById('petition-clh');
+
+  if (!button) return;
+
+  const currentPetitionId = String(button.dataset.petitionId);
+
+  if (!currentPetitionId) return;
+
+  const signForm = button.closest('form');
+
+  if (!signForm) return;
+
+  signForm.addEventListener('submit', () => {
+    const stored = getSignedPetitionIds();
+    const updated = [...new Set([...stored.map(String), currentPetitionId])];
+    localStorage.setItem('signedPetition', JSON.stringify(updated));
+
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 30);
+    document.cookie = `clh_signed_petitions=${encodeURIComponent(JSON.stringify(updated))};expires=${expires.toUTCString()};path=/;SameSite=Strict`;
+  });
+};
+
+export const stepperTunnelClh = () => {
+  const stepper = document.querySelector('.tunnel-clh-stepper');
+  if (!stepper) return;
+
+  const serverCount =
+    stepper?.dataset.signedCount !== undefined ? parseInt(stepper?.dataset.signedCount, 10) : null;
+
+  const localStorageIds = getSignedPetitionIds();
+  const checkedCount = serverCount || localStorageIds.length;
+  const limit = Math.min(checkedCount, stepper.children.length);
+
+  Array.from(stepper.children).forEach((child) => child.classList.remove('is-checked'));
+
+  for (let i = 0; i < limit; i++) {
+    stepper.children[i].classList.add('is-checked');
+  }
+};
+
 export const submitCodeOrigine = () => {
   const form = document.querySelector('.signature-petition-form');
 

--- a/private/src/styles/pages/page/type/_tunnel-clh.scss
+++ b/private/src/styles/pages/page/type/_tunnel-clh.scss
@@ -1,3 +1,31 @@
+.tunnel-clh-stepper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 32px;
+}
+
+.tunnel-clh-step {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    font-size: 14px;
+    font-weight: 600;
+    flex-shrink: 0;
+    color: #aaa;
+
+    &.is-checked {
+        background-color: #e8232a;
+        border-color: #e8232a;
+        color: #fff;
+    }
+}
+
 .tunnel-clh-layout {
     max-width: $container-md;
     margin-inline: auto;

--- a/wp-content/themes/humanity-theme/includes/blocks/slider-changez-leur-histoire/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/slider-changez-leur-histoire/render.php
@@ -18,7 +18,7 @@ if (!function_exists('render_slider_changez_leur_histoire_block')) {
         if ($active_campaign) {
             $petitions_list_clh = get_field('list_petition_clh', $active_campaign->ID) ?? [];
 
-            foreach (array_filter($petitions_list_clh, fn ($p) => amnesty_active_petitions_clh($p->ID)) as $petition) {
+            foreach (array_filter($petitions_list_clh, fn ($p) => amnesty_is_petition_not_expired($p->ID)) as $petition) {
                 $selected_posts[] = ['id' => $petition->ID];
             }
         } else {

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -368,6 +368,21 @@ function amnesty_handle_petition_signature(): void
 
     if ($is_clh_tunnel) {
         amnesty_set_clh_signer_email($user_email);
+
+        $cookie_signed = [];
+        if (!empty($_COOKIE['clh_signed_petitions'])) {
+            $decoded = json_decode(stripslashes($_COOKIE['clh_signed_petitions']), true);
+            if (is_array($decoded)) {
+                $cookie_signed = array_map('intval', $decoded);
+            }
+        }
+        $cookie_signed[] = $petition_id;
+        setcookie('clh_signed_petitions', wp_json_encode(array_unique($cookie_signed)), [
+            'expires'  => time() + 30 * DAY_IN_SECONDS,
+            'path'     => '/',
+            'secure'   => is_ssl(),
+            'samesite' => 'Strict',
+        ]);
     }
 
     $redirect_url = amnesty_get_petition_signature_redirect_url($petition_id, [

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -278,7 +278,7 @@ function amnesty_handle_petition_skip(): void
 }
 add_action('template_redirect', 'amnesty_handle_petition_skip');
 
-function amnesty_active_petitions_clh($petition_id): bool
+function amnesty_is_petition_not_expired($petition_id): bool
 {
     $end_date = get_field('date_de_fin', $petition_id);
     $end_date_timestamp = !empty($end_date) ? strtotime($end_date) : false;

--- a/wp-content/themes/humanity-theme/partials/petition-card-change-their-history.php
+++ b/wp-content/themes/humanity-theme/partials/petition-card-change-their-history.php
@@ -20,6 +20,17 @@ if (!$post_object instanceof WP_Post) {
     $percentage = ($goal > 0) ? min(($current / $goal) * 100, 100) : 0;
 } else {
     $permalink   = get_permalink($post_object);
+    $page_id =  get_queried_object_id();
+    $clh_campaign = amnesty_get_active_clh_campaign_for_page($page_id);
+    $is_active_campaign = $clh_campaign instanceof WP_Post;
+
+    if ($is_active_campaign && $clh_campaign->ID) {
+        $permalink = add_query_arg(
+            ['is_active_campaign_clh' => ''],
+            get_permalink($post_object)
+        );
+    }
+
     $title       = get_the_title($post_object);
     $date        = get_the_date('', $post_object);
     $thumbnail   = get_the_post_thumbnail($post_id, 'medium', ['class' => 'petition-image']);

--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -126,10 +126,6 @@ $is_campaign_clh = get_field('clh_petition', $post_id) && amnesty_is_clh_petitio
 								type="submit"
 								name="sign_petition"
 								class="custom-button"
-								<?php if ($is_campaign_clh) : ?>
-									id="petition-clh"
-									data-petition-id="<?php echo esc_attr($post_id) ?>"
-								<?php endif; ?>
 							>
 								<div class='content bg-yellow medium'>
 									<div class="icon-container">

--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -9,15 +9,15 @@
 
 $type = get_field('type')['value'] ?? 'petition';
 if ($type === 'action-soutien') {
-    $enable_user_message = get_field('autoriser_message_utilisateur');
-    $phone_required = get_field('phone_required');
-    $form_contenu = get_field('form_contenu');
-    $button_text = get_field('button_text');
-    $comment_max_length = (int)get_field('comment_max_length');
-    $terms = get_field('terms');
+	$enable_user_message = get_field('autoriser_message_utilisateur');
+	$phone_required = get_field('phone_required');
+	$form_contenu = get_field('form_contenu');
+	$button_text = get_field('button_text');
+	$comment_max_length = (int)get_field('comment_max_length');
+	$terms = get_field('terms');
 } else {
-    $punchline = get_field('punchline');
-    $recipient = get_field('destinataire');
+	$punchline = get_field('punchline');
+	$recipient = get_field('destinataire');
 }
 
 $current_date = date('Y-m-d');
@@ -28,131 +28,168 @@ $civility = $civility ?? 'M.';
 
 $turnstile_error_message = $GLOBALS['petition_turnstile_error_message'] ?? '';
 
+$is_campaign_clh = get_field('clh_petition', $post_id) && amnesty_is_clh_petition_tunnel_active();
+
 ?>
 
 <aside class="petition-aside" id="petition">
-  <div class="sticky-card">
-    <div class="sticky-card-content">
-      <div class="sticky-card-title">SIGNEZ LA PÉTITION</div>
-      <p class="recipient"><?php echo esc_html($recipient ?? ''); ?><?php echo esc_html($form_contenu ?? ''); ?></p>
-        <?php if ($type === 'petition') : ?>
-      <div class="punchline-wrapper">
-        <p class="punchline"><?php echo esc_html($punchline ?? ''); ?></p>
-        <div class="border"></div>
-      </div>
-        <?php endif; ?>
-		<?php if (isset($end_date) && (strtotime($end_date) >= strtotime($current_date))) : ?>
+	<div class="sticky-card">
+		<div class="sticky-card-content">
+			<div class="sticky-card-title">SIGNEZ LA PÉTITION</div>
+			<p class="recipient"><?php echo esc_html($recipient ?? ''); ?><?php echo esc_html($form_contenu ?? ''); ?></p>
+			<?php if ($type === 'petition') : ?>
+				<div class="punchline-wrapper">
+					<p class="punchline"><?php echo esc_html($punchline ?? ''); ?></p>
+					<div class="border"></div>
+				</div>
+			<?php endif; ?>
+			<?php if (isset($end_date) && (strtotime($end_date) >= strtotime($current_date))) : ?>
 
-      <form class="signature-petition-form" method="post" action="">
-          <div class="cf-turnstile" data-sitekey="<?php echo esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
-          <?php if ($turnstile_error_message) : ?>
-              <?php aif_include_partial('alert', ['state' => 'error', 'title' => 'Une erreur est survenue', 'content' => $turnstile_error_message]); ?>
-          <?php endif; ?>
-          <?php if ($type === 'action-soutien' && $enable_user_message) : ?>
-          <div class="message-section">
-              <textarea class="message-input" type="text" name="user_message" placeholder="Votre message* (<?= $comment_max_length ?> caractères max)" required maxlength="<?= $comment_max_length ?>"></textarea>
-          </div>
-          <?php endif; ?>
-        <div class="email-section">
-          <input class="email-input" type="email" name="user_email" placeholder="Email*" required>
-          <input type="hidden" name="petition_id" value="<?php echo esc_attr($post_id); ?>">
-        </div>
-
-        <div class="full-form">
-          <div class="form-group civility-section">
-            <label class="civility-label">Civilité :</label>
-            <div class="civilities">
-              <input type="radio" id="civility_m" name="civility" value="M." <?php echo ($civility === 'M.') ? 'checked' : ''; ?>>
-              <label for="civility_m">M.</label>
-              <input type="radio" id="civility_mme" name="civility" value="Mme" <?php echo ($civility === 'Mme') ? 'checked' : ''; ?>>
-              <label for="civility_mme">Mme</label>
-              <input type="radio" id="civility_other" name="civility" value="Autre" <?php echo ($civility === 'Autre') ? 'checked' : ''; ?>>
-              <label for="civility_other">Autre</label>
-            </div>
-          </div>
-
-          <div class="firstname-section">
-            <input class="firstname-input" type="text" name="user_firstname" placeholder="Prénom*">
-            <input type="hidden" name="petition_id" value="<?php echo esc_attr($post_id); ?>">
-          </div>
-
-          <div class="lastname-section">
-            <input class="lastname-input" type="text" name="user_lastname" placeholder="Nom*">
-          </div>
-
-          <div class="zipcode-and-country">
-            <div class="zipcode-section">
-              <input class="zipcode-input" type="text" name="user_zipcode" placeholder="Code postal*">
-            </div>
-
-            <div class="country-section">
-              <select class="country-input " name="user_country">
-                <option value=""><?php _e('Pays*', 'textdomain'); ?></option>
-                <?php
-                $countries = get_posts([
-                    'post_type' => 'fiche_pays',
-                    'posts_per_page' => -1,
-                    'orderby' => 'title',
-                    'order' => 'ASC',
-                ]);
-
-		    foreach ($countries as $country) :
-		        $country_name = get_the_title($country->ID);
-		        ?>
-                <option value="<?php echo esc_attr($country_name); ?>" <?php if (esc_attr($country_name) === 'France') :?> selected="selected"<?php endif;?>>
-                  <?php echo esc_html(ucwords(strtolower($country_name))); ?>
-                </option>
-                <?php endforeach; ?>
-              </select>
-            </div>
-          </div>
-
-          <div class="phone-section">
-            <input class="phone-input" type="tel" name="user_phone" placeholder="Téléphone">
-          </div>
-        </div>
-
-        <div class="sign-and-legals">
-          <div class="custom-button-block center">
-              <button type="submit" name="sign_petition" class="custom-button">
-                  <div class='content bg-yellow medium'>
-                      <div class="icon-container">
-                          <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              strokeWidth="1.5"
-                              stroke="currentColor"
-                          >
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-                          </svg>
-                      </div>
-                      <div class="button-label"><?php if (isset($button_text) && ! empty($button_text)) : ?><?php echo esc_html($button_text) ?><?php else : ?>Signer<?php endif;?></div>
-                  </div>
-              </button>
-          </div>
-          <div class="legals">
-              <?php if (isset($terms) && ! empty($terms)) : ?>
-                  <?php the_field('terms'); ?>
-              <?php else : ?>
-                  <p>Les données personnelles collectées sur ce formulaire sont traitées par l’association Amnesty International France (AIF), responsable du traitement. Ces données vont nous permettre de vous envoyer nos propositions d’engagement, qu’elles soient militantes ou financières. Notre politique de confidentialité détaille la manière dont Amnesty International France, en sa qualité de responsable de traitement, traite et protège vos données personnelles collectées conformément aux dispositions de la Loi du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés dite Loi « Informatique et Libertés », et au Règlement européen du 25 mai 2018 sur la protection des données (« RGPD »). Pour toute demande, vous pouvez contacter le service membres et donateurs d’AIF à l’adresse mentionnée ci-dessus, par email <span class="by-email"><a href="mailto:smd@amnesty.fr">smd@amnesty.fr</a></span> ou par téléphone 01 53 38 65 80. Vous pouvez également introduire une réclamation auprès de la CNIL. Pour plus d’information sur le traitement de vos données personnelles, veuillez consulter <span class="privacy-policy"><a href="/politique-de-confidentialite">notre politique de confidentialité</a></span></p>
-              <?php endif; ?>
-          </div>
-        </div>
-      </form>
-		<?php else : ?>
-		<div class="close-petition">
-			<p>Cette pétition est <strong>terminée</strong>, merci pour votre soutien.</p>
-			<p>N'hésitez pas à signer une des autres pétitions disponibles.</p>
-			<div class="custom-button-block center">
-				<a href="/petitions" class="custom-button">
-					<div class='content outline-black medium'>
-						<div class="button-label">Toutes nos pétitions</div>
+				<form class="signature-petition-form" method="post" action="">
+					<div class="cf-turnstile"
+					     data-sitekey="<?php echo esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
+					<?php if ($turnstile_error_message) : ?>
+						<?php aif_include_partial('alert', ['state' => 'error', 'title' => 'Une erreur est survenue', 'content' => $turnstile_error_message]); ?>
+					<?php endif; ?>
+					<?php if ($type === 'action-soutien' && $enable_user_message) : ?>
+						<div class="message-section">
+							<textarea class="message-input" type="text" name="user_message"
+							          placeholder="Votre message* (<?= $comment_max_length ?> caractères max)" required
+							          maxlength="<?= $comment_max_length ?>"></textarea>
+						</div>
+					<?php endif; ?>
+					<div class="email-section">
+						<input class="email-input" type="email" name="user_email" placeholder="Email*" required>
+						<input type="hidden" name="petition_id" value="<?php echo esc_attr($post_id); ?>">
 					</div>
-				</a>
-			</div>
+
+					<div class="full-form">
+						<div class="form-group civility-section">
+							<label class="civility-label">Civilité :</label>
+							<div class="civilities">
+								<input type="radio" id="civility_m" name="civility"
+								       value="M." <?php echo ($civility === 'M.') ? 'checked' : ''; ?>>
+								<label for="civility_m">M.</label>
+								<input type="radio" id="civility_mme" name="civility"
+								       value="Mme" <?php echo ($civility === 'Mme') ? 'checked' : ''; ?>>
+								<label for="civility_mme">Mme</label>
+								<input type="radio" id="civility_other" name="civility"
+								       value="Autre" <?php echo ($civility === 'Autre') ? 'checked' : ''; ?>>
+								<label for="civility_other">Autre</label>
+							</div>
+						</div>
+
+						<div class="firstname-section">
+							<input class="firstname-input" type="text" name="user_firstname" placeholder="Prénom*">
+						</div>
+
+						<div class="lastname-section">
+							<input class="lastname-input" type="text" name="user_lastname" placeholder="Nom*">
+						</div>
+
+						<div class="zipcode-and-country">
+							<div class="zipcode-section">
+								<input class="zipcode-input" type="text" name="user_zipcode" placeholder="Code postal*">
+							</div>
+
+							<div class="country-section">
+								<select class="country-input " name="user_country">
+									<option value=""><?php _e('Pays*', 'textdomain'); ?></option>
+									<?php
+									$countries = get_posts([
+										'post_type' => 'fiche_pays',
+										'posts_per_page' => -1,
+										'orderby' => 'title',
+										'order' => 'ASC',
+									]);
+
+									foreach ($countries as $country) :
+										$country_name = get_the_title($country->ID);
+										?>
+										<option
+											value="<?php echo esc_attr($country_name); ?>" <?php if (esc_attr($country_name) === 'France') : ?> selected="selected"<?php endif; ?>>
+											<?php echo esc_html(ucwords(strtolower($country_name))); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+							</div>
+						</div>
+
+						<div class="phone-section">
+							<input class="phone-input" type="tel" name="user_phone" placeholder="Téléphone">
+						</div>
+					</div>
+
+					<div class="sign-and-legals">
+						<div class="custom-button-block center">
+							<button
+								type="submit"
+								name="sign_petition"
+								class="custom-button"
+								<?php if ($is_campaign_clh) : ?>
+									id="petition-clh"
+									data-petition-id="<?php echo esc_attr($post_id) ?>"
+								<?php endif; ?>
+							>
+								<div class='content bg-yellow medium'>
+									<div class="icon-container">
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											strokeWidth="1.5"
+											stroke="currentColor"
+										>
+											<path strokeLinecap="round" strokeLinejoin="round"
+											      d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"/>
+										</svg>
+									</div>
+									<div class="button-label">
+										<?php if (isset($button_text) && !empty($button_text)) : ?><?php echo esc_html($button_text) ?><?php else : ?>
+											Signer
+										<?php endif; ?>
+
+									</div>
+								</div>
+							</button>
+						</div>
+						<div class="legals">
+							<?php if (isset($terms) && !empty($terms)) : ?>
+								<?php the_field('terms'); ?>
+							<?php else : ?>
+								<p>Les données personnelles collectées sur ce formulaire sont traitées par l’association
+									Amnesty International France (AIF), responsable du traitement. Ces données vont nous
+									permettre de vous envoyer nos propositions d’engagement, qu’elles soient militantes
+									ou financières. Notre politique de confidentialité détaille la manière dont Amnesty
+									International France, en sa qualité de responsable de traitement, traite et protège
+									vos données personnelles collectées conformément aux dispositions de la Loi du 6
+									janvier 1978 relative à l’informatique, aux fichiers et aux libertés dite Loi «
+									Informatique et Libertés », et au Règlement européen du 25 mai 2018 sur la
+									protection des données (« RGPD »). Pour toute demande, vous pouvez contacter le
+									service membres et donateurs d’AIF à l’adresse mentionnée ci-dessus, par email <span
+										class="by-email"><a href="mailto:smd@amnesty.fr">smd@amnesty.fr</a></span> ou
+									par téléphone 01 53 38 65 80. Vous pouvez également introduire une réclamation
+									auprès de la CNIL. Pour plus d’information sur le traitement de vos données
+									personnelles, veuillez consulter <span class="privacy-policy"><a
+											href="/politique-de-confidentialite">notre politique de confidentialité</a></span>
+								</p>
+							<?php endif; ?>
+						</div>
+					</div>
+				</form>
+			<?php else : ?>
+				<div class="close-petition">
+					<p>Cette pétition est <strong>terminée</strong>, merci pour votre soutien.</p>
+					<p>N'hésitez pas à signer une des autres pétitions disponibles.</p>
+					<div class="custom-button-block center">
+						<a href="/petitions" class="custom-button">
+							<div class='content outline-black medium'>
+								<div class="button-label">Toutes nos pétitions</div>
+							</div>
+						</a>
+					</div>
+				</div>
+			<?php endif; ?>
 		</div>
-		<?php endif; ?>
-    </div>
-  </div>
+	</div>
 </aside>

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -17,7 +17,7 @@ $parent = $post->post_parent;
 $active_campaign = amnesty_get_active_clh_campaign_for_page($parent);
 
 if (!$active_campaign) {
-    wp_redirect('/');
+    wp_redirect('/'); // TODO: REDIRECT IF NO ACTIVE CAMPAIGN
     exit();
 }
 
@@ -28,6 +28,14 @@ $raw_email = $_SESSION['clh_last_signer_email'] ?? null;
 
 $last_signer_email = ($raw_email && is_email($raw_email)) ? sanitize_email($raw_email) : null;
 $current_user = $last_signer_email ? get_local_user($last_signer_email) : false;
+
+$cookie_signed_ids = [];
+if (!$last_signer_email && !empty($_COOKIE['clh_signed_petitions'])) {
+    $decoded = json_decode(stripslashes($_COOKIE['clh_signed_petitions']), true);
+    if (is_array($decoded)) {
+        $cookie_signed_ids = array_map('intval', $decoded);
+    }
+}
 $list_petitions_clh = get_field('list_petition_clh', $active_campaign->ID);
 
 if (empty($list_petitions_clh)) {
@@ -42,20 +50,20 @@ foreach ($list_petitions_clh as $petition) {
     $selected_posts[] = [
         'id' => $petition->ID,
         'title' => $petition->post_title,
-        'already_signed' => $last_signer_email && $current_user && have_signed($petition->ID, $current_user->id),
-        'active' => amnesty_active_petitions_clh($petition->ID),
+        'already_signed' => ($last_signer_email && $current_user && have_signed($petition->ID, $current_user->id))
+            || in_array($petition->ID, $cookie_signed_ids, true),
+        'active' => amnesty_is_petition_not_expired($petition->ID),
         'already_skipped' => in_array($petition->ID, $skipped_petitions, true),
     ];
 }
-$signed_count  = count(array_filter($selected_posts, fn ($p) => $p['already_signed'] === true));
-$total_steps   = min(10, count($list_petitions_clh));
+$signed_count = count(array_filter($selected_posts, fn ($p) => $p['already_signed'] === true));
+$total_steps  = min(10, count($list_petitions_clh));
 
 $not_signed = \array_filter(
     $selected_posts,
-    static fn ($petition) =>
-    $petition['already_signed'] === false &&
-    $petition['already_skipped'] === false &&
-    $petition['active'] === true
+    static fn ($petition) => $petition['already_signed'] === false &&
+        $petition['already_skipped'] === false &&
+        $petition['active'] === true
 );
 
 if ($signed_count >= 10 || empty($not_signed)) {
@@ -72,7 +80,7 @@ $next_petition = $not_signed[$random_key];
 	<!-- wp:group {"tagName":"section","className":"page-content"} -->
 	<section class="wp-block-group page-content">
 		<div class="tunnel-clh-layout">
-			<div class="tunnel-clh-stepper">
+			<div class="tunnel-clh-stepper" data-signed-count="<?=esc_attr($signed_count); ?>">
 				<?php for ($i = 0; $i < $total_steps; $i++) : ?>
 					<div class="tunnel-clh-step <?= $i < $signed_count ? 'is-checked' : ''; ?>">
 						<?php if ($i < $signed_count) : ?>
@@ -86,12 +94,13 @@ $next_petition = $not_signed[$random_key];
 			<div
 				class="tunnel-clh-card"
 				<?php if ($last_signer_email) : ?>
-				data-email="<?= esc_attr($last_signer_email); ?>"
+					data-email="<?= esc_attr($last_signer_email); ?>"
 				<?php endif; ?>
 			>
 				<?php $thumbnail_url = get_the_post_thumbnail_url($next_petition['id'], 'full'); ?>
 				<?php if ($thumbnail_url) : ?>
-					<img src="<?= esc_url($thumbnail_url); ?>" alt="<?= esc_attr(get_the_title($next_petition['id'])); ?>">
+					<img src="<?= esc_url($thumbnail_url); ?>"
+					     alt="<?= esc_attr(get_the_title($next_petition['id'])); ?>">
 				<?php endif; ?>
 
 				<h2><?= esc_html(get_the_title($next_petition['id'])); ?></h2>
@@ -105,15 +114,21 @@ $next_petition = $not_signed[$random_key];
 						</div>
 					<?php endif; ?>
 					<div class="cf-turnstile" data-sitekey="<?= esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"></div>
-					<input type="hidden" name="petition_id" value="<?= esc_attr((string) $next_petition['id']); ?>">
+					<input type="hidden" name="petition_id" value="<?= esc_attr((string)$next_petition['id']); ?>">
 					<input type="hidden" name="from_tunnel" value="1">
 					<?php if ($last_signer_email) : ?>
 						<input type="hidden" name="user_email" value="<?= esc_attr($last_signer_email); ?>">
 					<?php endif; ?>
-					<button type="submit" name="sign_petition">Signer la pétition</button>
+					<button
+						type="submit"
+						name="sign_petition"
+						id="petition-clh"
+						data-petition-id="<?php echo esc_attr($next_petition['id']) ?>">
+						Signer la pétition
+					</button>
 				</form>
 				<form class="tunnel-clh-skip-form" method="post" action="">
-					<input type="hidden" name="petition_id" value="<?= esc_attr((string) $next_petition['id']); ?>">
+					<input type="hidden" name="petition_id" value="<?= esc_attr((string)$next_petition['id']); ?>">
 					<?php if ($last_signer_email) : ?>
 						<input type="hidden" name="user_email" value="<?= esc_attr($last_signer_email); ?>">
 					<?php endif; ?>

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -121,9 +121,7 @@ $next_petition = $not_signed[$random_key];
 					<?php endif; ?>
 					<button
 						type="submit"
-						name="sign_petition"
-						id="petition-clh"
-						data-petition-id="<?php echo esc_attr($next_petition['id']) ?>">
+						name="sign_petition">
 						Signer la pétition
 					</button>
 				</form>


### PR DESCRIPTION
## Contexte

Implémentation de la sauvegarde du parcours utilisateur dans le tunnel CLH.

🔗 [MAINT-200 – Tunnel CLH : Sauvegarde du parcours utilisateur et reprise de la progression](https://linear.app/les-tilleuls/issue/MAINT-200)

## Ce que fait cette PR

- **Stepper de progression** : affichage d'une timeline de 1 à 10 étapes cochées au fur et à mesure des signatures, rendu côté serveur et synchronisé côté client via `stepperTunnelClh()`
- **Sauvegarde localStorage** : les IDs des pétitions signées sont persistés dans `localStorage.signedPetition` et dans le cookie `clh_signed_petitions` (30 jours) via `getPetitionIdForCLH()`
- **Reprise de progression** : au rechargement du tunnel, le PHP lit le cookie `clh_signed_petitions` pour reconstituer les pétitions déjà signées côté serveur (`$cookie_signed_ids`) sans dépendance à la session
- **Renommage** : `amnesty_active_petitions_clh` → `amnesty_is_petition_not_expired` pour un nommage plus explicite

## Test

1. Signer plusieurs pétitions dans le tunnel → vérifier que le stepper avance
2. Fermer le navigateur, rouvrir → vérifier que les pétitions déjà signées ne réapparaissent pas
3. Vérifier que le slider CLH n'affiche plus les pétitions expirées