### PR TITLE
Feature/quick sign form retention#maint 206

### DIFF
--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -67,19 +67,30 @@ function amnesty_get_petition_signature_count($post_id): int
 if (!function_exists('amnesty_get_clh_petition_tunnel_page')) {
     function amnesty_get_clh_petition_tunnel_page(): ?WP_Post
     {
+        // get_page_by_path() issues a DB query every call and is not object-cached by WordPress.
+        // This function is called from amnesty_get_clh_petition_tunnel_url(), which is itself called
+        // on every petition page load (signature redirect) and on every skip/sign handler.
+        // A static variable with a false sentinel (false = not yet evaluated, null = evaluated & not found)
+        // ensures the two DB queries run at most once per request regardless of how many call sites invoke it.
+        static $cache = false;
+
+        if ($cache !== false) {
+            return $cache;
+        }
+
         $clh_page = get_page_by_path('nous-connaitre/nos-combats/changez-leur-histoire/tunnel-clh');
 
         if ($clh_page instanceof WP_Post) {
-            return $clh_page;
+            return $cache = $clh_page;
         }
 
         $clh_page = get_page_by_path('tunnel-clh');
 
         if ($clh_page instanceof WP_Post) {
-            return $clh_page;
+            return $cache = $clh_page;
         }
 
-        return null;
+        return $cache = null;
     }
 }
 
@@ -101,33 +112,56 @@ if (!function_exists('amnesty_get_clh_petition_tunnel_url')) {
 if (!function_exists('amnesty_get_clh_petition_campaign_page')) {
     function amnesty_get_clh_petition_campaign_page(): ?WP_Post
     {
+        // Same caching rationale as amnesty_get_clh_petition_tunnel_page(): get_page_by_path() is an
+        // uncached DB query. This function is now called unconditionally on every petition page render
+        // (via amnesty_is_clh_petition_tunnel_active() in aside-petition-sticky.php), so without a cache
+        // it issues up to 2 DB queries per request regardless of whether a CLH campaign is active.
+        // false = not yet evaluated; null = evaluated, page not found in DB.
+        static $cache = false;
+
+        if ($cache !== false) {
+            return $cache;
+        }
+
         $clh_page = get_page_by_path('nous-connaitre/nos-combats/changez-leur-histoire');
 
         if ($clh_page instanceof WP_Post) {
-            return $clh_page;
+            return $cache = $clh_page;
         }
 
         $clh_page = get_page_by_path('changez-leur-histoire');
 
         if ($clh_page instanceof WP_Post) {
-            return $clh_page;
+            return $cache = $clh_page;
         }
 
-        return null;
+        return $cache = null;
     }
 }
 
 if (!function_exists('amnesty_get_active_clh_campaign_for_page')) {
     function amnesty_get_active_clh_campaign_for_page(int $page_id): ?WP_Post
     {
+        // This function makes up to 4 get_field() calls (highlight_clh, campaign_clh,
+        // start_date_highligth_clh, end_date_highlight_clh). ACF caches field values per post ID
+        // within a request, but the function itself is invoked from multiple call sites on the same
+        // page (aside-petition-sticky, slider block render, petition-card partial, tunnel content pattern).
+        // A per-page-id static cache avoids redundant ACF lookups and keeps the hot path cheap.
+        // false = not yet evaluated for this page_id; null = evaluated, no active campaign found.
+        static $cache = [];
+
+        if (array_key_exists($page_id, $cache)) {
+            return $cache[$page_id];
+        }
+
         if (!get_field('highlight_clh', $page_id)) {
-            return null;
+            return $cache[$page_id] = null;
         }
 
         $campaign = get_field('campaign_clh', $page_id);
 
         if (!$campaign instanceof WP_Post) {
-            return null;
+            return $cache[$page_id] = null;
         }
 
         $timestamp_now   = current_time('timestamp');
@@ -137,14 +171,14 @@ if (!function_exists('amnesty_get_active_clh_campaign_for_page')) {
         $timestamp_end   = $end_date ? strtotime((string) $end_date) : 0;
 
         if ($timestamp_start > $timestamp_now) {
-            return null;
+            return $cache[$page_id] = null;
         }
 
         if ($timestamp_end <= $timestamp_now) {
-            return null;
+            return $cache[$page_id] = null;
         }
 
-        return $campaign;
+        return $cache[$page_id] = $campaign;
     }
 }
 
@@ -381,6 +415,14 @@ function amnesty_handle_petition_signature(): void
             'expires'  => time() + 30 * DAY_IN_SECONDS,
             'path'     => '/',
             'secure'   => is_ssl(),
+            'samesite' => 'Strict',
+        ]);
+
+        setcookie('clh_user_email', $user_email, [
+            'expires'  => time() + 30 * DAY_IN_SECONDS,
+            'path'     => '/',
+            'secure'   => is_ssl(),
+            'httponly' => false,
             'samesite' => 'Strict',
         ]);
     }

--- a/wp-content/themes/humanity-theme/partials/petition-card-change-their-history.php
+++ b/wp-content/themes/humanity-theme/partials/petition-card-change-their-history.php
@@ -20,17 +20,6 @@ if (!$post_object instanceof WP_Post) {
     $percentage = ($goal > 0) ? min(($current / $goal) * 100, 100) : 0;
 } else {
     $permalink   = get_permalink($post_object);
-    $page_id =  get_queried_object_id();
-    $clh_campaign = amnesty_get_active_clh_campaign_for_page($page_id);
-    $is_active_campaign = $clh_campaign instanceof WP_Post;
-
-    if ($is_active_campaign && $clh_campaign->ID) {
-        $permalink = add_query_arg(
-            ['is_active_campaign_clh' => ''],
-            get_permalink($post_object)
-        );
-    }
-
     $title       = get_the_title($post_object);
     $date        = get_the_date('', $post_object);
     $thumbnail   = get_the_post_thumbnail($post_id, 'medium', ['class' => 'petition-image']);

--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -9,15 +9,15 @@
 
 $type = get_field('type')['value'] ?? 'petition';
 if ($type === 'action-soutien') {
-	$enable_user_message = get_field('autoriser_message_utilisateur');
-	$phone_required = get_field('phone_required');
-	$form_contenu = get_field('form_contenu');
-	$button_text = get_field('button_text');
-	$comment_max_length = (int)get_field('comment_max_length');
-	$terms = get_field('terms');
+    $enable_user_message = get_field('autoriser_message_utilisateur');
+    $phone_required = get_field('phone_required');
+    $form_contenu = get_field('form_contenu');
+    $button_text = get_field('button_text');
+    $comment_max_length = (int)get_field('comment_max_length');
+    $terms = get_field('terms');
 } else {
-	$punchline = get_field('punchline');
-	$recipient = get_field('destinataire');
+    $punchline = get_field('punchline');
+    $recipient = get_field('destinataire');
 }
 
 $current_date = date('Y-m-d');
@@ -96,16 +96,16 @@ $is_campaign_clh = get_field('clh_petition', $post_id) && amnesty_is_clh_petitio
 								<select class="country-input " name="user_country">
 									<option value=""><?php _e('Pays*', 'textdomain'); ?></option>
 									<?php
-									$countries = get_posts([
-										'post_type' => 'fiche_pays',
-										'posts_per_page' => -1,
-										'orderby' => 'title',
-										'order' => 'ASC',
-									]);
+                                    $countries = get_posts([
+                                        'post_type' => 'fiche_pays',
+                                        'posts_per_page' => -1,
+                                        'orderby' => 'title',
+                                        'order' => 'ASC',
+                                    ]);
 
-									foreach ($countries as $country) :
-										$country_name = get_the_title($country->ID);
-										?>
+			    foreach ($countries as $country) :
+			        $country_name = get_the_title($country->ID);
+			        ?>
 										<option
 											value="<?php echo esc_attr($country_name); ?>" <?php if (esc_attr($country_name) === 'France') : ?> selected="selected"<?php endif; ?>>
 											<?php echo esc_html(ucwords(strtolower($country_name))); ?>

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 amnesty_start_secure_session();
 
-$post   = get_post();
+$post = get_post();
 $parent = $post->post_parent;
 
 $active_campaign = amnesty_get_active_clh_campaign_for_page($parent);
@@ -21,10 +21,10 @@ if (!$active_campaign) {
     exit();
 }
 
-$end_date  = get_field('end_date_highlight_clh', $active_campaign->ID);
+$end_date = get_field('end_date_highlight_clh', $active_campaign->ID);
 $countdown = strtotime($end_date) - time();
 
-$raw_email = $_SESSION['clh_last_signer_email'] ?? null;
+$raw_email = $_SESSION['clh_last_signer_email'] ?? $_COOKIE['clh_user_email'] ?? null;
 
 $last_signer_email = ($raw_email && is_email($raw_email)) ? sanitize_email($raw_email) : null;
 $current_user = $last_signer_email ? get_local_user($last_signer_email) : false;
@@ -57,7 +57,7 @@ foreach ($list_petitions_clh as $petition) {
     ];
 }
 $signed_count = count(array_filter($selected_posts, fn ($p) => $p['already_signed'] === true));
-$total_steps  = min(10, count($list_petitions_clh));
+$total_steps = min(10, count($list_petitions_clh));
 
 $not_signed = \array_filter(
     $selected_posts,
@@ -80,7 +80,7 @@ $next_petition = $not_signed[$random_key];
 	<!-- wp:group {"tagName":"section","className":"page-content"} -->
 	<section class="wp-block-group page-content">
 		<div class="tunnel-clh-layout">
-			<div class="tunnel-clh-stepper" data-signed-count="<?=esc_attr($signed_count); ?>">
+			<div class="tunnel-clh-stepper" data-signed-count="<?= esc_attr($signed_count); ?>">
 				<?php for ($i = 0; $i < $total_steps; $i++) : ?>
 					<div class="tunnel-clh-step <?= $i < $signed_count ? 'is-checked' : ''; ?>">
 						<?php if ($i < $signed_count) : ?>


### PR DESCRIPTION
## Contexte

Maintien des données du formulaire pour la signature rapide dans le tunnel CLH.

🔗 [MAINT-206 – Tunnel CLH : Maintien des données du formulaire pour la signature rapide](https://linear.app/les-tilleuls/issue/MAINT-206)

## Ce que fait cette PR

- **Persistance de l'email** : l'email du signataire est conservé en session PHP (`$_SESSION['clh_last_signer_email']`) et en cookie 30 jours (`clh_user_email`) via `setTunnelClhCookie()`. Le tunnel lit en priorité la session, puis le cookie en fallback
- **Signature en un clic** : dès l'étape 2, si l'email est connu, `initTunnelClhForm()` injecte un champ hidden et soumet le formulaire sans afficher l'étape email
- **Détection CLH côté serveur** : `aside-petition-sticky.php` identifie les pétitions CLH via `get_field('clh_petition')` + `amnesty_is_clh_petition_tunnel_active()` au lieu d'un paramètre GET manipulable
- **Cache des requêtes DB** : `amnesty_get_clh_petition_tunnel_page()`, `amnesty_get_clh_petition_campaign_page()` et `amnesty_get_active_clh_campaign_for_page()` utilisent désormais un cache statique par requête HTTP pour éviter des appels `get_page_by_path()` et `get_field()` répétés sur chaque page pétition

## Test

1. Signer une première pétition dans le tunnel → vérifier que les étapes suivantes se soumettent en un clic
2. Quitter le site, revenir → vérifier que l'email est pré-rempli depuis le cookie
3. Sur une page pétition CLH (`?is_active_campaign_clh` supprimé) : vérifier que le comportement CLH s'active automatiquement via le champ ACF