### PR TITLE
fix(deploy): use production env for schema update

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -29,13 +29,18 @@ jobs:
           SSH_USER: ${{ secrets.PROD_SSH_USER }}
           SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
           SSH_HOST: ${{ secrets.PROD_SSH_HOST }}
-      - name: debug
-        run: |
-          cat ~/.ssh/prod.key
-          cat ~/.ssh/config
-
       - name: Deploy
         run: ssh prod 'source ~/.bash_profile && cd github && bash livraison-prod.sh'
 
+      # Production exposes DOCUMENT_ROOT_PROD through ~/.bash_profile, not ~/initenv.sh.
+      # Use --path to make WP-CLI independent from the remote shell working directory.
+      # Fail early if DOCUMENT_ROOT_PROD is missing or does not point to a WordPress root.
       - name: Update schema
-        run: ssh prod 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT_PROD" && wp update-db-schema'
+        run: |
+          ssh prod '
+            set -e
+            source "$HOME/.bash_profile"
+            : "${DOCUMENT_ROOT_PROD:?DOCUMENT_ROOT_PROD is required}"
+            test -f "$DOCUMENT_ROOT_PROD/wp-load.php"
+            wp --path="$DOCUMENT_ROOT_PROD" update-db-schema
+          '


### PR DESCRIPTION
## Why

The production deploy workflow was sourcing `~/initenv.sh` before running `wp update-db-schema`.

On the production server, `DOCUMENT_ROOT_PROD` is exposed through `~/.bash_profile`, via the existing `prod_variables_2_envs.sh` helper that reads the `### env prod.amnesty.fr` crontab block. `~/initenv.sh` looks for a different `### START INITENV` block, so it leaves `DOCUMENT_ROOT_PROD` empty in the CD context.

As a result, WP-CLI was executed outside the WordPress root and reported that `update-db-schema` was not registered.

## What changed

- Source `~/.bash_profile` before the production schema update.
- Require `DOCUMENT_ROOT_PROD` to be set before continuing.
- Check that `wp-load.php` exists in `DOCUMENT_ROOT_PROD`.
- Run WP-CLI with `--path=""` so it does not depend on the remote working directory.
- Remove the debug step that printed the SSH key file.

## Verification

- Inspected production read-only through `amnesty-prod`.
- Confirmed `source ~/initenv.sh` leaves `DOCUMENT_ROOT_PROD` empty.
- Confirmed `source ~/.bash_profile` exposes `DOCUMENT_ROOT_PROD=/home/clients/.../sites/amnesty.fr`.
- Confirmed `wp-load.php` exists, WordPress is installed, and `update-db-schema` is registered with `wp --path="" help update-db-schema`.
- Ran `actionlint .github/workflows/deploy-prod.yaml`.