### PR TITLE
Fix document search title SQL escaping

### DIFF
--- a/wp-content/themes/humanity-theme/includes/document/rest_endpoint.php
+++ b/wp-content/themes/humanity-theme/includes/document/rest_endpoint.php
@@ -4,7 +4,10 @@ function title_filter($where, $wp_query)
 {
     global $wpdb;
     if ($search_term = $wp_query->get('search_title')) {
-        $where .= ' AND ' . $wpdb->posts . '.post_title LIKE \'%' . $wpdb->esc_like($search_term) . '%\'';
+        $where .= $wpdb->prepare(
+            ' AND ' . $wpdb->posts . '.post_title LIKE %s',
+            '%' . $wpdb->esc_like($search_term) . '%'
+        );
     }
     return $where;
 }


### PR DESCRIPTION
### Motivation
- Eliminate an SQL injection in the public REST document search endpoints where the `search_title` value was concatenated directly into a `WHERE ... LIKE` clause without proper SQL quoting.
- Preserve existing search semantics and wildcard escaping while ensuring the search term is safely quoted before being injected into SQL.

### Description
- Replace the ad-hoc string concatenation in `title_filter()` with `$wpdb->prepare()` and bind the `LIKE %s` parameter while keeping `$wpdb->esc_like()` to escape LIKE wildcards.
- Keep the existing `add_filter('posts_where', 'title_filter', 10, 2)` flow and REST route behavior unchanged so the endpoints' functionality is preserved.

### Testing
- Ran `php -l wp-content/themes/humanity-theme/includes/document/rest_endpoint.php` to verify PHP syntax and it passed.
- Executed a minimal `php -r` harness that stubs the needed WordPress APIs and verified a payload such as `abc' OR SLEEP(5)#` is contained inside the prepared `LIKE` string, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f39e3d7f8832d9ae982f5781f2655)