### PR TITLE
Fix SQL injection in training archive filters

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/archive-loop-trainings.php
+++ b/wp-content/themes/humanity-theme/patterns/archive-loop-trainings.php
@@ -14,47 +14,57 @@ $posts_per_page = 18;
 $offset = ($paged - 1) * $posts_per_page;
 
 $filter = '';
-$periode_filter = isset($_GET['qperiod']) ? $_GET['qperiod'] : null;
+$filter_values = [];
+$get_training_filter = static function ($key) {
+    if (!isset($_GET[$key])) {
+        return null;
+    }
+
+    $value = wp_unslash($_GET[$key]);
+    if (!is_scalar($value)) {
+        return null;
+    }
+
+    return sanitize_text_field((string) $value);
+};
+$periode_filter = $get_training_filter('qperiod');
 if ($periode_filter) {
-    $periodes = explode(',', $periode_filter);
+    $periodes = array_filter(array_map(static function ($periode) {
+        return str_replace('-', '', trim($periode));
+    }, explode(',', $periode_filter)));
+
     if (\count($periodes) > 1) {
-        $filter .= 'AND (';
+        $filter .= ' AND (' . implode(' OR ', array_fill(0, \count($periodes), 'm.meta_value LIKE %s')) . ')';
         foreach ($periodes as $periode) {
-            $periode = str_replace('-', '', $periode);
-            $filter .= "m.meta_value LIKE '{$periode}%' OR ";
+            $filter_values[] = $wpdb->esc_like($periode) . '%';
         }
-        $filter = substr($filter, 0, -4) . ')';
-    } else {
-        $periode_filter = str_replace('-', '', $periode_filter);
-        $filter .= " AND m.meta_value LIKE '{$periode_filter}%'";
+    } elseif (\count($periodes) === 1) {
+        $filter .= ' AND m.meta_value LIKE %s';
+        $filter_values[] = $wpdb->esc_like(reset($periodes)) . '%';
     }
 }
 
-$lieu_filter = isset($_GET['qlieu']) ? $_GET['qlieu'] : null;
+$lieu_filter = $get_training_filter('qlieu');
 if ($lieu_filter) {
-    $lieux = explode(',', $lieu_filter);
+    $lieux = array_filter(array_map('trim', explode(',', $lieu_filter)));
     if (\count($lieux) > 1) {
-        $filter .= ' AND m2.meta_value IN (';
-        foreach ($lieux as $lieu) {
-            $filter .= "'{$lieu}',";
-        }
-        $filter = substr($filter, 0, -1) . ')';
-    } else {
-        $filter .= " AND m2.meta_value = '{$lieu_filter}'";
+        $filter .= ' AND m2.meta_value IN (' . implode(', ', array_fill(0, \count($lieux), '%s')) . ')';
+        $filter_values = array_merge($filter_values, $lieux);
+    } elseif (\count($lieux) === 1) {
+        $filter .= ' AND m2.meta_value = %s';
+        $filter_values[] = reset($lieux);
     }
 }
 
-$categories_filter = isset($_GET['qcategories']) ? $_GET['qcategories'] : null;
+$categories_filter = $get_training_filter('qcategories');
 if ($categories_filter) {
-    $categories = explode(',', $categories_filter);
+    $categories = array_filter(array_map('trim', explode(',', $categories_filter)));
     if (\count($categories) > 1) {
-        $filter .= ' AND m3.meta_value IN (';
-        foreach ($categories as $category) {
-            $filter .= "'{$category}',";
-        }
-        $filter = substr($filter, 0, -1) . ')';
-    } else {
-        $filter .= " AND m3.meta_value = '{$categories_filter}'";
+        $filter .= ' AND m3.meta_value IN (' . implode(', ', array_fill(0, \count($categories), '%s')) . ')';
+        $filter_values = array_merge($filter_values, $categories);
+    } elseif (\count($categories) === 1) {
+        $filter .= ' AND m3.meta_value = %s';
+        $filter_values[] = reset($categories);
     }
 }
 
@@ -71,12 +81,12 @@ $meta_key_filter = '%session%date%de%debut';
 $meta_value_filter = '%field%';
 
 $total_query = "SELECT COUNT(1) AS count FROM ({$query}) AS combined_table";
-$total_result = $wpdb->prepare($total_query, $meta_key_filter, $meta_value_filter);
+$total_result = $wpdb->prepare($total_query, array_merge([$meta_key_filter, $meta_value_filter], $filter_values));
 $total = $wpdb->get_results($total_result)[0]->count;
 $max_num_page = ceil($total / $posts_per_page);
 $wpdb->max_num_pages = $max_num_page;
 
-$session_query = $wpdb->prepare(sprintf('%s LIMIT %d, %d', $query, $offset, $posts_per_page), $meta_key_filter, $meta_value_filter);
+$session_query = $wpdb->prepare(sprintf('%s LIMIT %d, %d', $query, $offset, $posts_per_page), array_merge([$meta_key_filter, $meta_value_filter], $filter_values));
 $raw_sessions = $wpdb->get_results($session_query);
 $sessions = [];
 foreach ($raw_sessions as $raw_session) {


### PR DESCRIPTION
### Motivation
- The training archive pattern built SQL by concatenating public `$_GET` values into the query, enabling unauthenticated SQL injection via `qperiod`, `qlieu`, and `qcategories`.
- The change aims to remove raw interpolation of attacker-controlled values and ensure all user input is sanitized and parameterized before being included in SQL.

### Description
- Reworked `wp-content/themes/humanity-theme/patterns/archive-loop-trainings.php` to stop interpolating raw `$_GET` values and introduced a scalar-only sanitization helper `$get_training_filter` for filter inputs.
- Built dynamic SQL filter fragments using `%s` placeholders and collected user-supplied values in a `$filter_values` array so all user data flows through `$wpdb->prepare()`.
- Escaped `qperiod` LIKE components with `$wpdb->esc_like()` and appended `%` where appropriate, and changed `IN`/`=` filters to use `%s` placeholders joined with `implode` instead of embedding raw values.
- Updated the `COUNT` and paginated session queries to merge `$filter_values` into the `$wpdb->prepare()` parameter list to ensure proper parameterization.

### Testing
- Ran `php -l wp-content/themes/humanity-theme/patterns/archive-loop-trainings.php` and received no syntax errors (success).
- Ran `git diff --check` to verify no whitespace/merge issues (success).
- Ran `composer lint` which failed in this environment because `./vendor/bin/phpcs` is not installed (environment limitation, not a regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f4bea6520832db917a30edbd608ec)