### PR TITLE
chore(format): add Prettier formatting baseline

### DIFF
--- a/private/.prettierignore
+++ b/private/.prettierignore
@@ -1,0 +1,7 @@
+node_modules/
+.yarn/
+playwright-report/
+test-results/
+coverage/
+build/
+dist/

--- a/private/.stylelintrc.json
+++ b/private/.stylelintrc.json
@@ -19,7 +19,7 @@
     "color-hex-length": "short",
     "color-named": "never",
     "color-no-invalid-hex": true,
-    "comment-empty-line-before": "always",
+    "comment-empty-line-before": null,
     "comment-whitespace-inside": "always",
     "declaration-block-no-duplicate-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
@@ -50,6 +50,7 @@
     "scss/at-if-closing-brace-newline-after": "always-last-in-chain",
     "scss/at-if-closing-brace-space-after": "always-intermediate",
     "scss/no-global-function-names": null,
+    "scss/operator-no-newline-after": null,
     "selector-attribute-quotes": "always",
     "selector-max-id": 0,
     "selector-no-qualifying-type": [

--- a/private/package.json
+++ b/private/package.json
@@ -22,6 +22,7 @@
     "lint:scripts": "eslint ./src/",
     "lint:styles": "stylelint \"src/**/*.scss\"",
     "lint": "yarn lint:scripts; yarn lint:styles",
+    "format": "prettier --write .",
     "env": "wp-env",
     "env:e2e": "wp-env --config=tests/e2e/.wp-env.e2e.json",
     "env:e2e:start": "yarn env:e2e start --update",

--- a/private/src/scripts/editor/blocks/post-list/components/DisplayAuthor.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/DisplayAuthor.jsx
@@ -114,7 +114,8 @@ class DisplayAuthor extends Component {
 
     api
       .getPostsFromAuthors(requestArguments, value)
-      .then((data = [], i, xhr) => { // eslint-disable-line
+      .then((data = [], i, xhr) => {
+        // eslint-disable-line
         const posts = data.map((p) => {
           if (!p.featured_media || p.featured_media < 1) {
             return {

--- a/private/src/scripts/editor/blocks/post-list/components/DisplaySelect.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/DisplaySelect.jsx
@@ -181,7 +181,8 @@ class DisplaySelect extends Component {
 
     return api
       .getPosts(requestArguments, this.state.taxonomy, this.state.term)
-      .then((data = [], i, xhr) => { // eslint-disable-line
+      .then((data = [], i, xhr) => {
+        // eslint-disable-line
         const posts = data.map((p) => {
           if (!p.featured_media || p.featured_media < 1) {
             return {

--- a/private/src/styles/admin.scss
+++ b/private/src/styles/admin.scss
@@ -1,7 +1,7 @@
-@import "admin/cmb2";
-@import "admin/user-profile";
-@import "admin/localisation-options";
-@import "admin/icon-picker-control";
+@import 'admin/cmb2';
+@import 'admin/user-profile';
+@import 'admin/localisation-options';
+@import 'admin/icon-picker-control';
 
 :root {
   --ms-base: 16;

--- a/private/src/styles/base/_container.scss
+++ b/private/src/styles/base/_container.scss
@@ -5,22 +5,26 @@
   padding: 0;
 }
 
-.container--small, .container--sm {
+.container--small,
+.container--sm {
   @extend %container;
   max-width: $container-sm;
 }
 
-.container--medium, .container--md {
+.container--medium,
+.container--md {
   @extend %container;
   max-width: $container-md;
 }
 
-.container--large, .container--lg {
+.container--large,
+.container--lg {
   @extend %container;
   max-width: $container-lg;
 }
 
-.container--huge, .container--hg {
+.container--huge,
+.container--hg {
   @extend %container;
   max-width: $container-hg;
 }

--- a/private/src/styles/base/_images-editor.scss
+++ b/private/src/styles/base/_images-editor.scss
@@ -1,6 +1,6 @@
 :root {
   // used in icon mixin
-  --amnesty-icon-path: url("../images/sprite.svg"), none;
+  --amnesty-icon-path: url('../images/sprite.svg'), none;
 }
 
 .image-metadata {

--- a/private/src/styles/base/_images.scss
+++ b/private/src/styles/base/_images.scss
@@ -1,6 +1,6 @@
 :root {
   // used in icon mixin
-  --amnesty-icon-path: url("../images/sprite.svg"), none;
+  --amnesty-icon-path: url('../images/sprite.svg'), none;
 }
 
 /**
@@ -13,9 +13,9 @@
  *    using `display: block;`.
  */
 img {
-  max-width: 100%;           /* 1 */
-  font-style: oblique;        /* 2 */
-  vertical-align: middle;    /* 3 */
+  max-width: 100%; /* 1 */
+  font-style: oblique; /* 2 */
+  vertical-align: middle; /* 3 */
 }
 
 /**
@@ -26,7 +26,8 @@ img {
  */
 img[width],        /* 1 */ /* stylelint-disable-line */
 img[height],       /* 1 */ /* stylelint-disable-line */
-.gm-style img {    /* 2 */ /* stylelint-disable-line */
+.gm-style img {
+  /* 2 */ /* stylelint-disable-line */
   max-width: none;
 }
 
@@ -41,7 +42,7 @@ figure {
 .has-caption {
   position: relative;
 
-  &[class*="wp-image-"] {
+  &[class*='wp-image-'] {
     display: inline-block;
   }
 }

--- a/private/src/styles/base/_jetpack-forms-editor.scss
+++ b/private/src/styles/base/_jetpack-forms-editor.scss
@@ -7,7 +7,7 @@
       .wp-block-button__link {
         padding: 14px 28px;
         border: 2px solid var(--wp--preset--color--primary);
-        background: var(--wp--preset--color--primary);;
+        background: var(--wp--preset--color--primary);
         color: var(--wp--preset--color--black);
         border-radius: 0;
         font-family: var(--wp--preset--font-family--secondary);

--- a/private/src/styles/base/_jetpack-forms.scss
+++ b/private/src/styles/base/_jetpack-forms.scss
@@ -1,4 +1,4 @@
-div[data-test="contact-form"] {
+div[data-test='contact-form'] {
   padding: 0 !important;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.15);
   margin-bottom: 48px;

--- a/private/src/styles/base/_links.scss
+++ b/private/src/styles/base/_links.scss
@@ -1,5 +1,5 @@
 a {
-  transition: color .3s ease-in-out;
+  transition: color 0.3s ease-in-out;
   text-decoration-skip-ink: auto;
 }
 

--- a/private/src/styles/base/_overlay.scss
+++ b/private/src/styles/base/_overlay.scss
@@ -17,7 +17,7 @@
   }
 }
 
-html[class*="-open"] .overlay,
+html[class*='-open'] .overlay,
 html.search-active .overlay {
   display: block;
 }

--- a/private/src/styles/base/_reset.scss
+++ b/private/src/styles/base/_reset.scss
@@ -11,11 +11,26 @@
  * remove all margins from certain elements.
  */
 body,
-h1, h2, h3, h4, h5, h6,
-p, blockquote, pre,
-dl, dd, ol, ul,
-form, fieldset, legend,
-table, th, td, caption,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+dl,
+dd,
+ol,
+ul,
+form,
+fieldset,
+legend,
+table,
+th,
+td,
+caption,
 hr {
   margin: 0;
   padding: 0;
@@ -123,7 +138,8 @@ textarea {
  * 1. Remove the inheritance of text transform in Firefox.
  */
 button,
-select { /* 1 */
+select {
+  /* 1 */
   text-transform: none;
 }
 
@@ -131,9 +147,9 @@ select { /* 1 */
  * Correct the inability to style clickable types in iOS and Safari.
  */
 button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
+[type='button'],
+[type='reset'],
+[type='submit'] {
   -webkit-appearance: button;
 }
 
@@ -141,9 +157,9 @@ button,
  * Remove the inner border and padding in Firefox.
  */
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -152,9 +168,9 @@ button::-moz-focus-inner,
  * Restore the focus styles unset by the previous rule.
  */
 button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -188,8 +204,8 @@ progress {
 /**
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -197,7 +213,7 @@ progress {
  * 1. Correct the odd appearance in Chrome and Safari.
  * 2. Correct the outline style in Safari.
  */
-[type="search"] {
+[type='search'] {
   -webkit-appearance: textfield; /* 1 */
   outline-offset: -2px; /* 2 */
 }
@@ -205,7 +221,7 @@ progress {
 /**
  * Remove the inner padding in Chrome and Safari on macOS.
  */
-[type="search"]::-webkit-search-decoration {
+[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 

--- a/private/src/styles/base/_shared.scss
+++ b/private/src/styles/base/_shared.scss
@@ -2,11 +2,22 @@
  * Where `margin-bottom` is concerned, this value will be the same as the
  * base line-height. This allows us to keep a consistent vertical rhythm.
  */
-h1, h2, h3, h4, h5, h6, hgroup,
-ul, ol, dl,
-blockquote, p, address,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hgroup,
+ul,
+ol,
+dl,
+blockquote,
+p,
+address,
 table,
-fieldset, figure,
+fieldset,
+figure,
 pre,
 %margin-bottom {
   margin-bottom: var(--wp--preset--spacing--single);
@@ -16,7 +27,9 @@ pre,
  * Where `margin-left` is concerned we want to try and indent certain elements
  * by a consistent amount. Define that amount once,here.
  */
-ul, ol, dd,
+ul,
+ol,
+dd,
 %margin-left {
   margin-left: var(--wp--preset--spacing--double);
 }

--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -1,5 +1,5 @@
 .wp-block-group.custom-card {
-  width:100%;
+  width: 100%;
 
   .wp-block-buttons {
     padding-left: 8px;

--- a/private/src/styles/blocks/banner/_main.scss
+++ b/private/src/styles/blocks/banner/_main.scss
@@ -1,1 +1,1 @@
-@import "./subscribe-to-the-chronicle-banner";
+@import './subscribe-to-the-chronicle-banner';

--- a/private/src/styles/blocks/carousel/_main.scss
+++ b/private/src/styles/blocks/carousel/_main.scss
@@ -49,7 +49,7 @@
     font-weight: bold;
     line-height: 12px;
     text-align: right;
-    background: linear-gradient(0deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.00) 100%);
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0) 100%);
     border-bottom: 6px solid var(--wp--preset--color--primary);
     box-sizing: border-box;
   }
@@ -58,7 +58,9 @@
     display: block;
     opacity: 0;
     transform: translateY(6px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s ease;
   }
 
   .swiper-slide-active .carousel-caption-text {

--- a/private/src/styles/blocks/change-their-history-toc/_main.scss
+++ b/private/src/styles/blocks/change-their-history-toc/_main.scss
@@ -2,7 +2,6 @@
   background-color: var(--wp--preset--color--grey-lightest);
   padding: 44px 0;
 
-
   &.is-empty {
     display: none;
   }

--- a/private/src/styles/blocks/collapsable/_main.scss
+++ b/private/src/styles/blocks/collapsable/_main.scss
@@ -52,7 +52,7 @@
   display: block;
   pointer-events: none;
   transform: rotate(180deg);
-  transition: transform .3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
 }
 
 .wp-block-amnesty-core-collapsable .icon-arrow-down {

--- a/private/src/styles/blocks/content-callout/_main.scss
+++ b/private/src/styles/blocks/content-callout/_main.scss
@@ -1,8 +1,8 @@
 .content-callout {
   width: 95%;
-  padding: 1.1rem .9rem 1.7rem .9rem;
-  border-top: .45rem solid var(--wp--preset--color--black);
-  border-bottom: .45rem solid var(--wp--preset--color--black);
+  padding: 1.1rem 0.9rem 1.7rem 0.9rem;
+  border-top: 0.45rem solid var(--wp--preset--color--black);
+  border-bottom: 0.45rem solid var(--wp--preset--color--black);
   text-align: center;
 
   .container {

--- a/private/src/styles/blocks/core-blocks/_image.scss
+++ b/private/src/styles/blocks/core-blocks/_image.scss
@@ -10,7 +10,7 @@
   float: left;
 }
 
-.wp-block-image [class*="wp-image-"] {
+.wp-block-image [class*='wp-image-'] {
   max-width: 100%;
 }
 

--- a/private/src/styles/blocks/core-blocks/_latest-posts.scss
+++ b/private/src/styles/blocks/core-blocks/_latest-posts.scss
@@ -16,7 +16,9 @@
   overflow: hidden;
   text-overflow: ellipsis;
   background-color: var(--wp--preset--color--white);
-  transition: .25s ease-in-out, color .25s ease-in-out;
+  transition:
+    0.25s ease-in-out,
+    color 0.25s ease-in-out;
   display: flex;
 }
 

--- a/private/src/styles/blocks/core-blocks/_menu.scss
+++ b/private/src/styles/blocks/core-blocks/_menu.scss
@@ -3,7 +3,9 @@
   border: 1px solid var(--wp--preset--color--grey-lighter);
 }
 
-.postlist-categories a:active, .postlist-categories a:hover, .postlist-categories a:focus {
+.postlist-categories a:active,
+.postlist-categories a:hover,
+.postlist-categories a:focus {
   background-color: var(--wp--preset--color--grey-light);
 }
 

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -10,7 +10,7 @@
 
 .wp-block-quote cite::after,
 .wp-block-quote.has-text-align-center cite::after {
-  content: "";
+  content: '';
   display: block;
   margin: 8px auto 0;
   max-width: 200px;
@@ -107,8 +107,6 @@
     font-size: 1.25rem !important;
   }
 }
-
-
 
 .wp-block-quote cite::after,
 .wp-block-quote.has-black-color cite::after,

--- a/private/src/styles/blocks/core-blocks/_separator.scss
+++ b/private/src/styles/blocks/core-blocks/_separator.scss
@@ -19,7 +19,7 @@
 }
 
 .wp-block-separator.is-style-dots::before {
-  content: "\00b7 \00b7 \00b7";
+  content: '\00b7 \00b7 \00b7';
   padding-left: 2em;
   font-size: var(--wp--preset--font-size--regular);
   color: var(--wp--preset--color--black);

--- a/private/src/styles/blocks/core-blocks/_table.scss
+++ b/private/src/styles/blocks/core-blocks/_table.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 .wp-block-table {
   width: 100%;
@@ -58,8 +58,8 @@
   }
 }
 
-.wp-block-table th:not([class*="has-text-align"]),
-.wp-block-table td:not([class*="has-text-align"]) {
+.wp-block-table th:not([class*='has-text-align']),
+.wp-block-table td:not([class*='has-text-align']) {
   text-align: center;
 }
 

--- a/private/src/styles/blocks/core-blocks/post-title/_main.scss
+++ b/private/src/styles/blocks/core-blocks/post-title/_main.scss
@@ -14,7 +14,9 @@
 
 .wp-block-post-title.post-title span {
   background-color: var(--wp--preset--color--white);
-  box-shadow: -8px 0 0 0 var(--wp--preset--color--white), 8px 0 0 0 var(--wp--preset--color--white);
+  box-shadow:
+    -8px 0 0 0 var(--wp--preset--color--white),
+    8px 0 0 0 var(--wp--preset--color--white);
   box-decoration-break: clone;
   line-height: 1.2;
 }

--- a/private/src/styles/blocks/core-blocks/post/_main.scss
+++ b/private/src/styles/blocks/core-blocks/post/_main.scss
@@ -31,7 +31,7 @@
 }
 
 .wp-block-post:not(.has-post-thumbnail) .post-content::after {
-  content: "";
+  content: '';
   display: block;
   height: 8px;
   width: 75%;

--- a/private/src/styles/blocks/core-blocks/query-pagination/_main.scss
+++ b/private/src/styles/blocks/core-blocks/query-pagination/_main.scss
@@ -1,7 +1,7 @@
-@import "./container";
-@import "./next";
-@import "./previous";
-@import "./numbers";
+@import './container';
+@import './next';
+@import './previous';
+@import './numbers';
 
 .wp-block-query-pagination > .wp-block-query-pagination-previous,
 .wp-block-query-pagination > .wp-block-query-pagination-next,

--- a/private/src/styles/blocks/hero/_editor.scss
+++ b/private/src/styles/blocks/hero/_editor.scss
@@ -1,11 +1,11 @@
-[data-type="amnesty-core/hero"] {
+[data-type='amnesty-core/hero'] {
   margin-inline: auto !important;
   max-width: $flexy-container !important;
   width: 100% !important;
   float: none !important;
 }
 
-[data-type="amnesty-core/hero"] .wp-block {
+[data-type='amnesty-core/hero'] .wp-block {
   max-width: 100%;
 }
 
@@ -45,56 +45,56 @@
   position: absolute;
 }
 
-[data-type="amnesty-core/hero"] .has-donation-block .hero-contentWrapper,
+[data-type='amnesty-core/hero'] .has-donation-block .hero-contentWrapper,
 .wp-block-amnesty-core-hero .has-donation-block .hero-contentWrapper {
   max-width: 840px;
 }
 
-[data-type="amnesty-core/hero"] .has-donation-block .hero-content,
+[data-type='amnesty-core/hero'] .has-donation-block .hero-content,
 .wp-block-amnesty-core-hero .has-donation-block .hero-content {
   max-width: 460px;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align],
+[data-type='amnesty-core/hero'] .wp-block[data-align],
 .wp-block[data-align] .wp-block-amnesty-core-hero {
   height: auto;
   min-height: 540px;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="left"] .container,
-.wp-block[data-align="left"] .wp-block-amnesty-core-hero .container {
+[data-type='amnesty-core/hero'] .wp-block[data-align='left'] .container,
+.wp-block[data-align='left'] .wp-block-amnesty-core-hero .container {
   justify-content: start;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="left"] .hero-contentWrapper,
-.wp-block[data-align="left"] .wp-block-amnesty-core-hero .hero-contentWrapper {
+[data-type='amnesty-core/hero'] .wp-block[data-align='left'] .hero-contentWrapper,
+.wp-block[data-align='left'] .wp-block-amnesty-core-hero .hero-contentWrapper {
   align-items: start;
   text-align: start;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="center"] .container,
-.wp-block[data-align="center"] .wp-block-amnesty-core-hero .container {
+[data-type='amnesty-core/hero'] .wp-block[data-align='center'] .container,
+.wp-block[data-align='center'] .wp-block-amnesty-core-hero .container {
   justify-content: center;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="center"] .hero-contentWrapper,
-.wp-block[data-align="center"] .wp-block-amnesty-core-hero .hero-contentWrapper {
+[data-type='amnesty-core/hero'] .wp-block[data-align='center'] .hero-contentWrapper,
+.wp-block[data-align='center'] .wp-block-amnesty-core-hero .hero-contentWrapper {
   align-items: center;
   text-align: center;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="right"] .container,
-.wp-block[data-align="right"] .wp-block-amnesty-core-hero .container {
+[data-type='amnesty-core/hero'] .wp-block[data-align='right'] .container,
+.wp-block[data-align='right'] .wp-block-amnesty-core-hero .container {
   justify-content: end;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align="right"] .hero-contentWrapper,
-.wp-block[data-align="right"] .wp-block-amnesty-core-hero .hero-contentWrapper {
+[data-type='amnesty-core/hero'] .wp-block[data-align='right'] .hero-contentWrapper,
+.wp-block[data-align='right'] .wp-block-amnesty-core-hero .hero-contentWrapper {
   align-items: end;
   text-align: end;
 }
 
-[data-type="amnesty-core/hero"] .wp-block[data-align] .container.has-donation-block,
+[data-type='amnesty-core/hero'] .wp-block[data-align] .container.has-donation-block,
 .wp-block[data-align] .wp-block-amnesty-core-hero .container.has-donation-block {
   justify-content: space-between;
 }

--- a/private/src/styles/blocks/linklist/_main.scss
+++ b/private/src/styles/blocks/linklist/_main.scss
@@ -38,7 +38,7 @@
 
   &::after {
     position: absolute;
-    content: "";
+    content: '';
     top: 0;
     right: 0;
     bottom: 0;
@@ -104,7 +104,7 @@
 }
 
 .linkList-authorDivider::before {
-  content: " ";
+  content: ' ';
   height: 12px;
   width: 1px;
   background: var(--wp--preset--color--black);

--- a/private/src/styles/blocks/list-block/_editor.scss
+++ b/private/src/styles/blocks/list-block/_editor.scss
@@ -2,7 +2,9 @@
   clear: both;
 }
 
-.wp-block[data-align="center"]:has(.block-editor-block-list__layout .block-editor-block-list__block) {
+.wp-block[data-align='center']:has(
+    .block-editor-block-list__layout .block-editor-block-list__block
+  ) {
   display: flex;
   justify-content: center;
 }

--- a/private/src/styles/blocks/petition-card-change-their-history/_main.scss
+++ b/private/src/styles/blocks/petition-card-change-their-history/_main.scss
@@ -1,4 +1,5 @@
-.petition-card-change-their-history, .action-card-change-their-history {
+.petition-card-change-their-history,
+.action-card-change-their-history {
   display: flex;
   background: var(--wp--preset--color--white);
   position: relative;
@@ -131,5 +132,4 @@
       text-transform: uppercase;
     }
   }
-
 }

--- a/private/src/styles/blocks/postlist/_categories-editor.scss
+++ b/private/src/styles/blocks/postlist/_categories-editor.scss
@@ -1,9 +1,9 @@
-[data-type="amnesty-core/block-menu"] {
+[data-type='amnesty-core/block-menu'] {
   max-width: 100% !important;
   width: 100% !important;
 }
 
-[data-type="amnesty-core/block-menu"] .postlist-categories {
+[data-type='amnesty-core/block-menu'] .postlist-categories {
   align-items: flex-start;
   box-sizing: border-box !important;
   margin: 0 !important;

--- a/private/src/styles/blocks/postlist/_header.scss
+++ b/private/src/styles/blocks/postlist/_header.scss
@@ -26,7 +26,7 @@
   font-size: var(--wp--preset--font-size--x-small);
   font-weight: bold;
   text-align: left;
-  letter-spacing: .3px;
+  letter-spacing: 0.3px;
 
   @include mq(xm-small) {
     margin-right: 16px;

--- a/private/src/styles/blocks/postlist/_pagination.scss
+++ b/private/src/styles/blocks/postlist/_pagination.scss
@@ -57,7 +57,7 @@
   margin-right: 16px;
   width: 16px;
   height: 16px;
-  background-image: url("../images/sprite.svg"), none;
+  background-image: url('../images/sprite.svg'), none;
   background-repeat: no-repeat;
   background-size: 313px 300px;
   background-position: -234px -240px;
@@ -97,7 +97,7 @@
 }
 
 .post-paginationLink button[disabled] .icon {
-  opacity: .4;
+  opacity: 0.4;
 }
 
 .post-paginationNext a,

--- a/private/src/styles/blocks/postlist/_post-editor.scss
+++ b/private/src/styles/blocks/postlist/_post-editor.scss
@@ -3,7 +3,7 @@
   align-items: center;
 
   &:hover {
-    background-color: color-mix(in srgb, var(--wp--preset--color--black) 5%, transparent);;
+    background-color: color-mix(in srgb, var(--wp--preset--color--black) 5%, transparent);
   }
 }
 

--- a/private/src/styles/blocks/postlist/_post-search.scss
+++ b/private/src/styles/blocks/postlist/_post-search.scss
@@ -62,7 +62,6 @@ ul.wp-block-post-template {
   font-family: var(--wp--preset--font-family--secondary);
   text-transform: uppercase;
   font-size: var(--wp--preset--font-size--small);
-
 }
 
 .post--result .post-location {
@@ -74,7 +73,7 @@ ul.wp-block-post-template {
 
 .post--result .post-title a::before {
   position: absolute;
-  content: "";
+  content: '';
   top: 0;
   right: 0;
   bottom: 0;

--- a/private/src/styles/blocks/postlist/_post.scss
+++ b/private/src/styles/blocks/postlist/_post.scss
@@ -8,13 +8,13 @@
 }
 
 @include mq(medium-sm) {
-  .tax-location .post+.post {
+  .tax-location .post + .post {
     margin-left: flexy-gutter();
   }
 }
 
 @include mq($until: medium-sm) {
-  .tax-location .post+.post {
+  .tax-location .post + .post {
     margin-top: flexy-gutter();
   }
 }
@@ -56,7 +56,9 @@
 
 .post-title span {
   background-color: var(--wp--preset--color--white);
-  box-shadow: -8px 0 0 0 var(--wp--preset--color--white), 8px 0 0 0 var(--wp--preset--color--white);
+  box-shadow:
+    -8px 0 0 0 var(--wp--preset--color--white),
+    8px 0 0 0 var(--wp--preset--color--white);
   box-decoration-break: clone;
   line-height: 1.2;
 }
@@ -112,7 +114,7 @@
 }
 
 .postImage--none .post-content::after {
-  content: "";
+  content: '';
   display: block;
   height: 8px;
   width: 75%;
@@ -138,7 +140,7 @@
 
 .post .post-figure img {
   backface-visibility: hidden;
-  transition: opacity .3s ease-in-out;
+  transition: opacity 0.3s ease-in-out;
 }
 
 .post-figure {
@@ -152,13 +154,13 @@
 .post:hover,
 .post:focus {
   .post-figure img {
-    opacity: .6;
+    opacity: 0.6;
   }
 }
 
 .post:focus-within {
   .post-figure img {
-    opacity: .6;
+    opacity: 0.6;
   }
 }
 

--- a/private/src/styles/blocks/rubric-heading/_main.scss
+++ b/private/src/styles/blocks/rubric-heading/_main.scss
@@ -1,6 +1,6 @@
 .rubric-heading {
   &__kicker {
-    margin: 0 0 .1rem 0;
+    margin: 0 0 0.1rem 0;
     font-size: 1.5rem;
     font-weight: bold;
     text-transform: uppercase;
@@ -9,7 +9,7 @@
   &__heading {
     position: relative;
     margin: 0 !important;
-    padding-bottom: .7rem;
+    padding-bottom: 0.7rem;
     font-size: 1.2rem;
     line-height: 1.6rem;
 

--- a/private/src/styles/blocks/tabbed-content/_main.scss
+++ b/private/src/styles/blocks/tabbed-content/_main.scss
@@ -32,7 +32,7 @@
   font-family: var(--wp--preset--font-family--secondary);
   min-height: 100% !important;
   cursor: pointer;
-  transition: background-color .5s ease;
+  transition: background-color 0.5s ease;
   white-space: unset;
   border: solid transparent !important;
   border-width: 0 0 6px 0 !important;
@@ -64,14 +64,14 @@
   border: none;
 }
 
-.wp-block-bigbite-tabs .tabsContainer button.tab[class*="is-selected"] {
+.wp-block-bigbite-tabs .tabsContainer button.tab[class*='is-selected'] {
   background: none !important;
   color: var(--wp--preset--color--black) !important;
   border: solid var(--wp--preset--color--black) !important;
   border-width: 0 0 6px 0 !important;
 }
 
-.wp-block-bigbite-tabs .tabsContainer.has-no-nav-arrows button.tab[class*="is-selected"] {
+.wp-block-bigbite-tabs .tabsContainer.has-no-nav-arrows button.tab[class*='is-selected'] {
   border: solid var(--wp--preset--color--black) !important;
   border-width: 0 0 6px 0 !important;
 }

--- a/private/src/styles/blocks/tabbed-content/editor.scss
+++ b/private/src/styles/blocks/tabbed-content/editor.scss
@@ -26,7 +26,7 @@
   border: none;
 }
 
-.wp-block-bigbite-tabs .tabsContainer button.tab[class*="is-selected"] {
+.wp-block-bigbite-tabs .tabsContainer button.tab[class*='is-selected'] {
   background: none !important;
   border-bottom: 6px solid var(--wp--preset--color--black) !important;
   color: var(--wp--preset--color--black) !important;

--- a/private/src/styles/components/_add-item.scss
+++ b/private/src/styles/components/_add-item.scss
@@ -7,7 +7,7 @@
   margin-top: 24px;
   padding: 24px;
   width: 100%;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   background-color: var(--wp--preset--color--white);
   border: 1px solid var(--wp--preset--color--black);
 

--- a/private/src/styles/components/_back-to-top.scss
+++ b/private/src/styles/components/_back-to-top.scss
@@ -9,7 +9,7 @@
   cursor: pointer;
   line-height: 0;
   z-index: 1000;
-  transition: all .3s ease-in-out;
+  transition: all 0.3s ease-in-out;
 
   &.hidden {
     visibility: hidden;

--- a/private/src/styles/components/_social.scss
+++ b/private/src/styles/components/_social.scss
@@ -22,14 +22,14 @@
 .social-twitter::after,
 .social-youtube::after,
 .social-telegram::after {
-  content: "";
+  content: '';
   position: absolute;
   top: calc(50% - 10px);
   left: calc(50% - 10px);
   display: block;
   width: 20px;
   height: 20px;
-  background-image: url("../images/sprite.svg"), none;
+  background-image: url('../images/sprite.svg'), none;
   background-repeat: no-repeat;
   background-size: 313px 300px;
   visibility: visible;

--- a/private/src/styles/components/_urgent-register.scss
+++ b/private/src/styles/components/_urgent-register.scss
@@ -1,8 +1,7 @@
 .urgent-register,
 .urgent-register-header,
 .urgent-register-form,
-.urgent-register-form-cta
-{
+.urgent-register-form-cta {
   display: flex;
   flex-direction: column;
 }
@@ -20,7 +19,7 @@
     padding: 8px 12px;
     background-color: var(--wp--preset--color--black);
     color: var(--wp--preset--color--primary);
-    top: -.9em;
+    top: -0.9em;
     left: 50%;
     transform: translateX(-50%);
     font-size: 1rem;
@@ -68,10 +67,12 @@
       }
     }
 
-    input:not([type="radio"]) {
+    input:not([type='radio']) {
       margin-bottom: 22px;
       border: 1px solid var(--wp--preset--color--grey-lighter);
-      transition: border 0.3s ease, margin-bottom 0.3s ease;
+      transition:
+        border 0.3s ease,
+        margin-bottom 0.3s ease;
       font-size: 16px;
 
       &.success {
@@ -131,7 +132,7 @@
             align-items: center;
             gap: 12px;
 
-            & > input[type="radio"] {
+            & > input[type='radio'] {
               cursor: pointer;
             }
 
@@ -223,5 +224,5 @@
       color: var(--wp--preset--color--success);
       border: 1px solid var(--wp--preset--color--success);
     }
-}
+  }
 }

--- a/private/src/styles/components/form/_all.scss
+++ b/private/src/styles/components/form/_all.scss
@@ -1,5 +1,5 @@
-@import "./fieldset";
-@import "./checkbox-group";
-@import "./select2";
-@import "./input";
-@import "./woocommerce";
+@import './fieldset';
+@import './checkbox-group';
+@import './select2';
+@import './input';
+@import './woocommerce';

--- a/private/src/styles/components/form/_fieldset.scss
+++ b/private/src/styles/components/form/_fieldset.scss
@@ -2,7 +2,7 @@ fieldset {
   margin: 12px -12px;
   padding: 12px;
   border: none;
-  background-color: rgba(0, 0, 0, .1);
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 fieldset legend {

--- a/private/src/styles/components/form/_input-editor.scss
+++ b/private/src/styles/components/form/_input-editor.scss
@@ -15,7 +15,7 @@ label.components-toggle-control__label {
   font-weight: normal;
 }
 
-.postbox input[type="radio"]:checked::before {
+.postbox input[type='radio']:checked::before {
   display: none;
 }
 

--- a/private/src/styles/components/form/_select2.scss
+++ b/private/src/styles/components/form/_select2.scss
@@ -12,7 +12,10 @@
   opacity: 1;
 }
 
-.element-select .select2-container--default .select2-selection--single .select2-selection__rendered {
+.element-select
+  .select2-container--default
+  .select2-selection--single
+  .select2-selection__rendered {
   padding: 0;
   font-weight: bold;
   line-height: normal;

--- a/private/src/styles/components/grid/_all.scss
+++ b/private/src/styles/components/grid/_all.scss
@@ -1,1 +1,1 @@
-@import "./item";
+@import './item';

--- a/private/src/styles/components/grid/_editor.scss
+++ b/private/src/styles/components/grid/_editor.scss
@@ -1,4 +1,4 @@
-[data-type="amnesty-core/block-list"] {
+[data-type='amnesty-core/block-list'] {
   max-width: 100% !important;
   width: 100% !important;
 }
@@ -102,7 +102,9 @@
 
   .post-selectorHeader input,
   .post-selectorHeader select {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-family:
+      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+      'Helvetica Neue', sans-serif;
     border-radius: 0;
     padding: 8px;
     font-size: var(--wp--preset--font-size--regular);
@@ -111,7 +113,7 @@
     max-height: none;
     height: auto;
     background-color: transparent;
-    transition: all .25s ease-in-out;
+    transition: all 0.25s ease-in-out;
     border-bottom: 2px solid transparent;
   }
 
@@ -188,7 +190,8 @@
     background-color: var(--wp--preset--color--grey-lighter);
     border: none;
     border-radius: 50%;
-    box-shadow: 1px 1px 5px 1px color-mix(in srgb, var(--wp--preset--color--grey-dark) 23%, transparent);
+    box-shadow: 1px 1px 5px 1px
+      color-mix(in srgb, var(--wp--preset--color--grey-dark) 23%, transparent);
     transform: translate(0, -50%);
   }
 
@@ -206,8 +209,10 @@
     border: none;
     color: var(--wp--preset--color--white);
     margin-bottom: 8px;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-    transition: all .25s ease-in-out;
+    font-family:
+      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+      'Helvetica Neue', sans-serif;
+    transition: all 0.25s ease-in-out;
   }
 
   .post-list > button:not([disabled]):hover,
@@ -217,7 +222,7 @@
   }
 
   .post-list > button[disabled] {
-    opacity: .7;
+    opacity: 0.7;
   }
 
   .blocks-plain-text {

--- a/private/src/styles/components/grid/_item.scss
+++ b/private/src/styles/components/grid/_item.scss
@@ -91,7 +91,9 @@ h3.grid-itemTitle > span,
 h3.grid-itemTitle > a {
   color: var(--wp--preset--color--black);
   background-color: var(--wp--preset--color--white);
-  box-shadow: -12px 0 0 0 var(--wp--preset--color--white), 12px 0 0 0 var(--wp--preset--color--white);
+  box-shadow:
+    -12px 0 0 0 var(--wp--preset--color--white),
+    12px 0 0 0 var(--wp--preset--color--white);
   box-decoration-break: clone;
   text-decoration: none;
   max-width: 100%;
@@ -99,7 +101,7 @@ h3.grid-itemTitle > a {
 
 .grid-itemTitle a::before {
   position: absolute;
-  content: "";
+  content: '';
   top: 0;
   right: 0;
   bottom: 0;
@@ -149,7 +151,7 @@ h3.grid-itemTitle > a {
   }
 }
 
-.grid-5 :nth-child(n+3) {
+.grid-5 :nth-child(n + 3) {
   grid-column: span 3;
 
   @include mq($from: x-small, $until: medium) {
@@ -161,7 +163,7 @@ h3.grid-itemTitle > a {
   }
 }
 
-.grid-5 :nth-child(-n+2) {
+.grid-5 :nth-child(-n + 2) {
   grid-column: span 3;
 
   @include mq($from: x-small, $until: medium) {
@@ -193,7 +195,7 @@ h3.grid-itemTitle > a {
   }
 }
 
-.grid-6 :nth-child(-n+2) {
+.grid-6 :nth-child(-n + 2) {
   grid-column: span 1;
 
   @include mq(x-small) {
@@ -217,7 +219,7 @@ h3.grid-itemTitle > a {
   }
 }
 
-.grid-7 :nth-child(-n+3) {
+.grid-7 :nth-child(-n + 3) {
   grid-column: span 1;
 
   @include mq(x-small) {
@@ -229,7 +231,7 @@ h3.grid-itemTitle > a {
   }
 }
 
-.grid-7 :nth-child(n+4) {
+.grid-7 :nth-child(n + 4) {
   grid-column: span 1;
 
   @include mq(x-small) {

--- a/private/src/styles/components/list/_all.scss
+++ b/private/src/styles/components/list/_all.scss
@@ -1,4 +1,4 @@
-@import "./base";
-@import "./inline";
-@import "./bare";
-@import "./dl";
+@import './base';
+@import './inline';
+@import './bare';
+@import './dl';

--- a/private/src/styles/components/media/_all.scss
+++ b/private/src/styles/components/media/_all.scss
@@ -1,2 +1,2 @@
-@import "./flex";
-@import "./floats";
+@import './flex';
+@import './floats';

--- a/private/src/styles/components/media/_flex.scss
+++ b/private/src/styles/components/media/_flex.scss
@@ -1,5 +1,4 @@
 @if ($enable-flexbox) {
-
   /**
    * Media object, flexbox style.
    *
@@ -19,9 +18,9 @@
   /// );
   /// <div class="media media--large">
   $media-figure-sizes: (
-    "large": "180px",
-    "medium": "140px",
-    "small": "100px"
+    'large': '180px',
+    'medium': '140px',
+    'small': '100px',
   ) !default;
 
   /// Media spacing amount.
@@ -54,7 +53,8 @@
   }
 
   .media-figure,
-  .media-figure img { /* 1 */ /* stylelint-disable-line */
+  .media-figure img {
+    /* 1 */ /* stylelint-disable-line */
     vertical-align: bottom;
   }
 
@@ -67,7 +67,8 @@
   .media-body {
     flex: 1;
 
-    &:last-child, > *:last-child {
+    &:last-child,
+    > *:last-child {
       margin-bottom: 0; /* 2 */
     }
   }
@@ -159,5 +160,4 @@
       float: none; /* 2 */
     }
   }
-
 }

--- a/private/src/styles/components/media/_floats.scss
+++ b/private/src/styles/components/media/_floats.scss
@@ -1,5 +1,4 @@
 @if ($enable-flexbox == false) {
-
   /**
    * Media object.
    *
@@ -19,9 +18,9 @@
   /// );
   /// <div class="media media--large">
   $media-figure-sizes: (
-    "large": "180px",
-    "medium": "140px",
-    "small": "100px"
+    'large': '180px',
+    'medium': '140px',
+    'small': '100px',
   ) !default;
 
   /// Media spacing amount.
@@ -53,7 +52,8 @@
   }
 
   .media-figure,
-  .media-figure img { /* 1 */ /* stylelint-disable-line */
+  .media-figure img {
+    /* 1 */ /* stylelint-disable-line */
     display: inline-block;
     vertical-align: bottom;
   }
@@ -67,7 +67,8 @@
   .media-body {
     overflow: hidden; /* 1 */
 
-    &:last-child, > *:last-child {
+    &:last-child,
+    > *:last-child {
       margin-bottom: 0; /* 2 */
     }
   }
@@ -165,7 +166,8 @@
       max-height: 100%;
     }
 
-    .media--valign.media--#{$key} > .media-figure img { /* 1 */
+    .media--valign.media--#{$key} > .media-figure img {
+      /* 1 */
       max-width: none; /* 2 */
       width: #{$value}; /* 3 */
     }
@@ -219,7 +221,7 @@
     .media--valign > .media-figure,
     .media--valign.media--flip .media-figure {
       padding-right: 0; /* 3 */
-      padding-left: 0;  /* 3 */
+      padding-left: 0; /* 3 */
     }
   }
 }

--- a/private/src/styles/components/modal/_base.scss
+++ b/private/src/styles/components/modal/_base.scss
@@ -12,13 +12,17 @@
   background-color: color-mix(in srgb, var(--wp--preset--color--grey-darkest) 80%, transparent);
   opacity: 0;
   z-index: -999;
-  transition: opacity .3s ease-in-out, z-index .3s step-end;
+  transition:
+    opacity 0.3s ease-in-out,
+    z-index 0.3s step-end;
 }
 
 .modal-container.is-open {
   z-index: 999;
   opacity: 1;
-  transition: opacity .3s ease-in-out, z-index .3s step-start;
+  transition:
+    opacity 0.3s ease-in-out,
+    z-index 0.3s step-start;
 }
 
 .modal-container .container {
@@ -29,8 +33,10 @@
   overscroll-behavior: contain;
   opacity: 0;
   transform: translateY(50px);
-  transition: opacity .3s ease-in-out, transform .3s ease-in-out;
-  transition-delay: .2s;
+  transition:
+    opacity 0.3s ease-in-out,
+    transform 0.3s ease-in-out;
+  transition-delay: 0.2s;
 
   @media screen and (max-height: 450px) {
     max-width: 450px;
@@ -56,7 +62,7 @@
 
 .modal-close::after {
   @include icon_scale(194px, 265px, 16px, 16px, 1);
-  content: "";
+  content: '';
   display: inline-block;
   margin-left: 8px;
 }

--- a/private/src/styles/components/pop-in/_main.scss
+++ b/private/src/styles/components/pop-in/_main.scss
@@ -6,8 +6,8 @@
   max-height: 1000px;
   overflow-y: hidden;
   transition-property: all;
-  transition-duration: .5s;
-  transition-timing-function: cubic-bezier(0, 1, .5, 1);
+  transition-duration: 0.5s;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
 }
 
 .pop-in.is-closed {
@@ -38,12 +38,12 @@
   }
 }
 
-.pop-in[aria-hidden="false"] ~ .page-header--transparent-light {
+.pop-in[aria-hidden='false'] ~ .page-header--transparent-light {
   background-color: var(--wp--preset--color--white);
   color: var(--wp--preset--color--black);
 }
 
 // negishim
-.pop-in[aria-hidden="false"] ~ .accessibility_component .btn_accessibility {
+.pop-in[aria-hidden='false'] ~ .accessibility_component .btn_accessibility {
   top: 165px;
 }

--- a/private/src/styles/gutenberg-hotfixes-content/_index.scss
+++ b/private/src/styles/gutenberg-hotfixes-content/_index.scss
@@ -31,11 +31,11 @@
       }
 
       &__heading {
-        padding-bottom: .7rem;
+        padding-bottom: 0.7rem;
       }
 
       ~ p {
-        margin-bottom: .7rem;
+        margin-bottom: 0.7rem;
       }
     }
 

--- a/private/src/styles/gutenberg-hotfixes-content/extends/_base.temp-file.scss
+++ b/private/src/styles/gutenberg-hotfixes-content/extends/_base.temp-file.scss
@@ -1,5 +1,4 @@
 %base-styles {
-
   /**
    * Apply box-sizing here, then inherit.
    * https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/

--- a/private/src/styles/gutenberg-hotfixes-content/extends/_reset.temp-file.scss
+++ b/private/src/styles/gutenberg-hotfixes-content/extends/_reset.temp-file.scss
@@ -7,17 +7,31 @@
  */
 
 %reset-styles {
-
   /**
    * It is often advantageous to
    * remove all margins from certain elements.
    */
   body,
-  h1, h2, h3, h4, h5, h6,
-  p, blockquote, pre,
-  dl, dd, ol, ul,
-  form, fieldset, legend,
-  table, th, td, caption,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  dl,
+  dd,
+  ol,
+  ul,
+  form,
+  fieldset,
+  legend,
+  table,
+  th,
+  td,
+  caption,
   hr {
     margin: 0;
     padding: 0;
@@ -125,7 +139,8 @@
    * 1. Remove the inheritance of text transform in Firefox.
    */
   button,
-  select { /* 1 */
+  select {
+    /* 1 */
     text-transform: none;
   }
 
@@ -133,9 +148,9 @@
    * Correct the inability to style clickable types in iOS and Safari.
    */
   button,
-  [type="button"],
-  [type="reset"],
-  [type="submit"] {
+  [type='button'],
+  [type='reset'],
+  [type='submit'] {
     -webkit-appearance: button;
   }
 
@@ -143,9 +158,9 @@
    * Remove the inner border and padding in Firefox.
    */
   button::-moz-focus-inner,
-  [type="button"]::-moz-focus-inner,
-  [type="reset"]::-moz-focus-inner,
-  [type="submit"]::-moz-focus-inner {
+  [type='button']::-moz-focus-inner,
+  [type='reset']::-moz-focus-inner,
+  [type='submit']::-moz-focus-inner {
     border-style: none;
     padding: 0;
   }
@@ -154,9 +169,9 @@
    * Restore the focus styles unset by the previous rule.
    */
   button:-moz-focusring,
-  [type="button"]:-moz-focusring,
-  [type="reset"]:-moz-focusring,
-  [type="submit"]:-moz-focusring {
+  [type='button']:-moz-focusring,
+  [type='reset']:-moz-focusring,
+  [type='submit']:-moz-focusring {
     outline: 1px dotted ButtonText;
   }
 
@@ -190,8 +205,8 @@
   /**
    * Correct the cursor style of increment and decrement buttons in Chrome.
    */
-  [type="number"]::-webkit-inner-spin-button,
-  [type="number"]::-webkit-outer-spin-button {
+  [type='number']::-webkit-inner-spin-button,
+  [type='number']::-webkit-outer-spin-button {
     height: auto;
   }
 
@@ -199,7 +214,7 @@
    * 1. Correct the odd appearance in Chrome and Safari.
    * 2. Correct the outline style in Safari.
    */
-  [type="search"] {
+  [type='search'] {
     -webkit-appearance: textfield; /* 1 */
     outline-offset: -2px; /* 2 */
   }
@@ -207,7 +222,7 @@
   /**
    * Remove the inner padding in Chrome and Safari on macOS.
    */
-  [type="search"]::-webkit-search-decoration {
+  [type='search']::-webkit-search-decoration {
     -webkit-appearance: none;
   }
 

--- a/private/src/styles/gutenberg-hotfixes-content/extends/_shared.temp-file.scss
+++ b/private/src/styles/gutenberg-hotfixes-content/extends/_shared.temp-file.scss
@@ -1,14 +1,24 @@
 %shared-styles {
-
   /**
    * Where `margin-bottom` is concerned, this value will be the same as the
    * base line-height. This allows us to keep a consistent vertical rhythm.
    */
-  h1, h2, h3, h4, h5, h6, hgroup,
-  ul, ol, dl,
-  blockquote, p, address,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  hgroup,
+  ul,
+  ol,
+  dl,
+  blockquote,
+  p,
+  address,
   table,
-  fieldset, figure,
+  fieldset,
+  figure,
   pre,
   %margin-bottom {
     margin-bottom: var(--wp--preset--spacing--single);
@@ -18,7 +28,9 @@
    * Where `margin-left` is concerned we want to try and indent certain elements
    * by a consistent amount. Define that amount once,here.
    */
-  ul, ol, dd,
+  ul,
+  ol,
+  dd,
   %margin-left {
     margin-left: var(--wp--preset--spacing--double);
   }

--- a/private/src/styles/gutenberg-hotfixes-content/extends/_type.temp-file.scss
+++ b/private/src/styles/gutenberg-hotfixes-content/extends/_type.temp-file.scss
@@ -1,5 +1,4 @@
 %type-styles {
-
   /**
    * Headings.
    */

--- a/private/src/styles/layout/_language-banner.scss
+++ b/private/src/styles/layout/_language-banner.scss
@@ -82,7 +82,7 @@ button.language-selectorClose {
 
 .language-selectorClose::after {
   @include icon(194px, 265px, 16px, 16px);
-  content: "";
+  content: '';
   display: inline-block;
   margin-left: 11px;
 

--- a/private/src/styles/layout/_page-hero-editor.scss
+++ b/private/src/styles/layout/_page-hero-editor.scss
@@ -1,4 +1,4 @@
-[data-type="amnesty-core/block-hero"] {
+[data-type='amnesty-core/block-hero'] {
   max-width: 100% !important;
   width: 100% !important;
 }
@@ -10,7 +10,6 @@
   background-size: cover;
   background-position: center center;
   color: var(--wp--preset--color--white);
-
 }
 
 .page-hero + .components-base-control {
@@ -172,7 +171,7 @@ p.page-heroContent {
   margin: 0;
 }
 
-.page-heroAlignment--right .editor-rich-text__tinymce[data-is-placeholder-visible="true"] {
+.page-heroAlignment--right .editor-rich-text__tinymce[data-is-placeholder-visible='true'] {
   right: 0;
 }
 

--- a/private/src/styles/layout/_page-hero.scss
+++ b/private/src/styles/layout/_page-hero.scss
@@ -49,7 +49,9 @@
 .page-heroTitle span {
   background-color: color-mix(in srgb, var(--wp--preset--color--black) 45%, transparent);
   color: var(--wp--preset--color--white);
-  box-shadow: 20px 0 0 color-mix(in srgb, var(--wp--preset--color--black) 45%, transparent), -20px 0 0 color-mix(in srgb, var(--wp--preset--color--black) 45%, transparent);
+  box-shadow:
+    20px 0 0 color-mix(in srgb, var(--wp--preset--color--black) 45%, transparent),
+    -20px 0 0 color-mix(in srgb, var(--wp--preset--color--black) 45%, transparent);
   box-decoration-break: clone;
 }
 
@@ -109,10 +111,14 @@ p.page-heroContent {
 }
 
 .page-heroBackground--dark .page-heroTitle span {
-  box-shadow: 16px 0 0 var(--wp--preset--color--black), -16px 0 0 var(--wp--preset--color--black);
+  box-shadow:
+    16px 0 0 var(--wp--preset--color--black),
+    -16px 0 0 var(--wp--preset--color--black);
 
   @include mq(xx-small) {
-    box-shadow: 20px 0 0 var(--wp--preset--color--black), -20px 0 0 var(--wp--preset--color--black);
+    box-shadow:
+      20px 0 0 var(--wp--preset--color--black),
+      -20px 0 0 var(--wp--preset--color--black);
   }
 }
 
@@ -124,10 +130,14 @@ p.page-heroContent {
 }
 
 .page-heroBackground--light .page-heroTitle span {
-  box-shadow: 16px 0 0 var(--wp--preset--color--white), -16px 0 0 var(--wp--preset--color--white);
+  box-shadow:
+    16px 0 0 var(--wp--preset--color--white),
+    -16px 0 0 var(--wp--preset--color--white);
 
   @include mq(xx-small) {
-    box-shadow: 20px 0 0 var(--wp--preset--color--white), -20px 0 0 var(--wp--preset--color--white);
+    box-shadow:
+      20px 0 0 var(--wp--preset--color--white),
+      -20px 0 0 var(--wp--preset--color--white);
   }
 }
 

--- a/private/src/styles/layout/header/_main.scss
+++ b/private/src/styles/layout/header/_main.scss
@@ -1,7 +1,7 @@
-@import "shared/base";
-@import "shared/logo";
-@import "shared/burger";
-@import "shared/button";
-@import "shared/search";
-@import "styles/light";
-@import "styles/transparent-light";
+@import 'shared/base';
+@import 'shared/logo';
+@import 'shared/burger';
+@import 'shared/button';
+@import 'shared/search';
+@import 'styles/light';
+@import 'styles/transparent-light';

--- a/private/src/styles/layout/header/shared/_base.scss
+++ b/private/src/styles/layout/header/shared/_base.scss
@@ -81,7 +81,6 @@
   display: flex;
   justify-content: space-between;
 
-
   .search-button-mobile {
     display: flex;
     justify-content: center;

--- a/private/src/styles/layout/header/shared/_search.scss
+++ b/private/src/styles/layout/header/shared/_search.scss
@@ -5,7 +5,7 @@
   @extend %icon-search-dark;
   display: inline-block;
   margin-left: var(--wp--preset--spacing--half);
-  content: "";
+  content: '';
 
   @include mq(mobile-nav) {
     margin-left: 0;

--- a/private/src/styles/layout/header/styles/_light.scss
+++ b/private/src/styles/layout/header/styles/_light.scss
@@ -1,3 +1,3 @@
-@import "./light/base";
-@import "./light/burger";
-@import "./light/search";
+@import './light/base';
+@import './light/burger';
+@import './light/search';

--- a/private/src/styles/layout/header/styles/_transparent-light.scss
+++ b/private/src/styles/layout/header/styles/_transparent-light.scss
@@ -1,3 +1,3 @@
-@import "./transparent-light/base";
-@import "./transparent-light/burger";
-@import "./transparent-light/search";
+@import './transparent-light/base';
+@import './transparent-light/burger';
+@import './transparent-light/search';

--- a/private/src/styles/pages/_author.scss
+++ b/private/src/styles/pages/_author.scss
@@ -54,12 +54,12 @@
   text-align: center;
 
   &::before {
-    content: " ";
+    content: ' ';
     display: inline-block;
-    transform: scale(.6);
+    transform: scale(0.6);
     vertical-align: -10%;
     pointer-events: none;
-    background-image: url("../images/sprite.svg"), none;
+    background-image: url('../images/sprite.svg'), none;
     background-repeat: no-repeat;
     background-size: 313px 353px;
     width: 20px;
@@ -118,7 +118,7 @@
 }
 
 .is-collapsed::before {
-  content: "";
+  content: '';
   width: 100%;
   height: 100%;
   position: absolute;
@@ -132,7 +132,7 @@
   max-height: 300px;
   overflow: hidden;
   text-overflow: ellipsis;
-  content: "";
+  content: '';
   position: relative;
 }
 

--- a/private/src/styles/pages/_events.scss
+++ b/private/src/styles/pages/_events.scss
@@ -160,7 +160,8 @@
             cursor: pointer;
             padding: 12px;
 
-            &:hover, &.active {
+            &:hover,
+            &.active {
               background-color: var(--wp--preset--color--grey-darkest);
               color: var(--wp--preset--color--white);
             }
@@ -258,7 +259,8 @@
         width: 16px;
         height: 16px;
         margin: 0 6px;
-        background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.78132 7.99999L5.48132 4.69999L6.42399 3.75732L10.6667 7.99999L6.42399 12.2427L5.48132 11.3L8.78132 7.99999Z' fill='%23575756'/%3E%3C/svg%3E") no-repeat center;
+        background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.78132 7.99999L5.48132 4.69999L6.42399 3.75732L10.6667 7.99999L6.42399 12.2427L5.48132 11.3L8.78132 7.99999Z' fill='%23575756'/%3E%3C/svg%3E")
+          no-repeat center;
         background-size: contain;
         vertical-align: middle;
       }

--- a/private/src/styles/pages/_news.scss
+++ b/private/src/styles/pages/_news.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 .blog main > .container:first-child {
   padding: 0;

--- a/private/src/styles/pages/_petitions.scss
+++ b/private/src/styles/pages/_petitions.scss
@@ -31,7 +31,7 @@
   &::before {
     padding: 0;
     width: auto;
-    content: "";
+    content: '';
   }
 }
 

--- a/private/src/styles/pages/_search.scss
+++ b/private/src/styles/pages/_search.scss
@@ -1,4 +1,4 @@
-@import "search/searchbox";
-@import "search/results";
-@import "search/results/filters";
-@import "search/results/active-filters";
+@import 'search/searchbox';
+@import 'search/results';
+@import 'search/results/filters';
+@import 'search/results/active-filters';

--- a/private/src/styles/pages/article/_back-link.scss
+++ b/private/src/styles/pages/article/_back-link.scss
@@ -11,7 +11,7 @@
 
   &::before {
     @include icon(290px, 200px, 17px, 11px);
-    content: " ";
+    content: ' ';
   }
 
   .rtl & {

--- a/private/src/styles/pages/article/_byline.scss
+++ b/private/src/styles/pages/article/_byline.scss
@@ -20,9 +20,9 @@
   }
 
   &::before {
-    content: " ";
+    content: ' ';
     display: inline-block;
-    transform: scale(.6);
+    transform: scale(0.6);
     vertical-align: -20%;
 
     @include icon(246px, 131px, 20px, 17px);

--- a/private/src/styles/pages/article/type/_petition.scss
+++ b/private/src/styles/pages/article/type/_petition.scss
@@ -25,13 +25,13 @@
       position: relative;
 
       &::after {
-        content: "";
+        content: '';
         position: absolute;
         width: 0;
         height: 0;
         border-color: transparent transparent transparent var(--wp--preset--color--black);
         border-style: solid;
-        border-width: 1.5rem 0 1.5rem .8125rem;
+        border-width: 1.5rem 0 1.5rem 0.8125rem;
         top: 0;
         right: 0;
         transform: translateX(100%);
@@ -47,7 +47,7 @@
       align-items: center;
 
       > svg {
-        margin-right: .3125rem;
+        margin-right: 0.3125rem;
         max-width: 1.25rem;
       }
     }
@@ -85,11 +85,11 @@
       z-index: 1;
       pointer-events: none;
       background: linear-gradient(
-          to bottom,
-          rgba(0, 0, 0, 0.9) 0%,
-          rgba(0, 0, 0, 0) 20%,
-          rgba(0, 0, 0, 0) 80%,
-          rgba(0, 0, 0, 0.9) 100%
+        to bottom,
+        rgba(0, 0, 0, 0.9) 0%,
+        rgba(0, 0, 0, 0) 20%,
+        rgba(0, 0, 0, 0) 80%,
+        rgba(0, 0, 0, 0.9) 100%
       );
     }
 
@@ -151,7 +151,8 @@
             width: 16px;
             height: 16px;
             margin: 0 6px;
-            background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.78132 7.99999L5.48132 4.69999L6.42399 3.75732L10.6667 7.99999L6.42399 12.2427L5.48132 11.3L8.78132 7.99999Z' fill='%23ffffff'/%3E%3C/svg%3E") no-repeat center;
+            background: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16' fill='none'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.78132 7.99999L5.48132 4.69999L6.42399 3.75732L10.6667 7.99999L6.42399 12.2427L5.48132 11.3L8.78132 7.99999Z' fill='%23ffffff'/%3E%3C/svg%3E")
+              no-repeat center;
             background-size: contain;
             vertical-align: middle;
           }
@@ -820,11 +821,13 @@
           }
         }
 
-        .email-section, .message-section {
+        .email-section,
+        .message-section {
           padding: 28px 24px;
           border-bottom: 1px solid var(--wp--preset--color--grey-light);
 
-          .email-input, .message-input {
+          .email-input,
+          .message-input {
             border: 1px solid var(--wp--preset--color--grey-light);
             font-size: var(--wp--preset--font-size--medium);
             text-transform: none;

--- a/private/src/styles/pages/article/type/_single-chronicle.scss
+++ b/private/src/styles/pages/article/type/_single-chronicle.scss
@@ -36,7 +36,8 @@
       width: 890px;
     }
 
-    &__aside, &__summary {
+    &__aside,
+    &__summary {
       flex-direction: column;
     }
 
@@ -49,7 +50,7 @@
 
       &.u-sticky {
         @media (min-width: $container-lg) {
-            top: 8rem;
+          top: 8rem;
         }
       }
 
@@ -76,14 +77,14 @@
           margin-bottom: 1.2rem;
 
           .custom-button .content.medium {
-            padding: .5rem 1.8rem;
+            padding: 0.5rem 1.8rem;
             font-size: 1rem;
           }
         }
 
         &:last-of-type {
           .custom-button .content.small {
-            padding: .3rem 1.2rem;
+            padding: 0.3rem 1.2rem;
           }
         }
       }
@@ -93,7 +94,7 @@
       flex: 1;
 
       .chip {
-        margin-bottom: .5rem;
+        margin-bottom: 0.5rem;
       }
 
       h2 {
@@ -105,7 +106,7 @@
         margin-bottom: 1.1rem;
 
         ~ p {
-          margin-bottom: .7rem;
+          margin-bottom: 0.7rem;
         }
       }
 
@@ -120,12 +121,12 @@
     margin: 1rem 0 1rem 0;
 
     @media (min-width: $container-lg) {
-      margin: 0 0 .8rem 0;
+      margin: 0 0 0.8rem 0;
     }
 
     .content {
       .title {
-        padding: .5rem .7rem !important;
+        padding: 0.5rem 0.7rem !important;
         margin-bottom: 2.5rem !important;
 
         @media (min-width: $container-lg) {

--- a/private/src/styles/pages/page/type/_changez-leur-histoire.scss
+++ b/private/src/styles/pages/page/type/_changez-leur-histoire.scss
@@ -26,97 +26,97 @@
     }
 
     .page-content {
-    padding-top: 0;
+      padding-top: 0;
 
-    &.no-chapo {
-      > :first-child {
-        margin-top: 24px;
+      &.no-chapo {
+        > :first-child {
+          margin-top: 24px;
 
-        .wp-block-heading {
-          margin-top: 0;
+          .wp-block-heading {
+            margin-top: 0;
+          }
+        }
+      }
+
+      .download-go-further-block,
+      .get-informed-block,
+      .read-also-block,
+      p:not(
+        .wp-block-amnesty-core-chapo p,
+        .wp-block-amnesty-core-section.small p,
+        .wp-block-amnesty-core-section.large p,
+        .download-go-further-block p,
+        .call-to-action-block p,
+        .wp-block-amnesty-core-section-home p,
+        .interactive-map p,
+        .wp-block-amnesty-core-card-image-text p,
+        .petition-card-change-their-history p
+      ),
+      .wp-block-columns,
+      .wp-block-details,
+      .wp-block-heading,
+      .wp-block-list,
+      .wp-block-amnesty-core-action,
+      .wp-block-amnesty-core-quote-block,
+      .wp-block-amnesty-core-image,
+      .wp-block-amnesty-core-section.small,
+      .wp-block-html,
+      .video-block,
+      .card-image-text-block,
+      .read-more-block,
+      .slider-block,
+      div[data-test='contact-form'] p,
+      div[data-test='contact-form'] {
+        max-width: $container-md;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .wp-block-image,
+      .image-block {
+        max-width: $container-lg;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .custom-button-block {
+        max-width: $container-md;
+        margin-left: auto;
+        margin-right: auto;
+        margin-bottom: 0;
+      }
+
+      .call-to-action-block {
+        max-width: $container-lg;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .wp-block-amnesty-core-chapo {
+        .text {
+          @media (min-width: $container-lg) {
+            width: 50%;
+            margin-left: 20%;
+          }
+        }
+      }
+
+      .interactive-map {
+        max-width: $container-hg;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .carousel-block {
+        width: 100vw;
+        margin-left: calc(50% - 50vw);
+        margin-right: calc(50% - 50vw);
+
+        .swiper-slide {
+          max-width: none;
         }
       }
     }
-
-    .download-go-further-block,
-    .get-informed-block,
-    .read-also-block,
-    p:not(
-      .wp-block-amnesty-core-chapo p,
-      .wp-block-amnesty-core-section.small p,
-      .wp-block-amnesty-core-section.large p,
-      .download-go-further-block p,
-      .call-to-action-block p,
-      .wp-block-amnesty-core-section-home p,
-      .interactive-map p,
-      .wp-block-amnesty-core-card-image-text p,
-      .petition-card-change-their-history p
-    ),
-    .wp-block-columns,
-    .wp-block-details,
-    .wp-block-heading,
-    .wp-block-list,
-    .wp-block-amnesty-core-action,
-    .wp-block-amnesty-core-quote-block,
-    .wp-block-amnesty-core-image,
-    .wp-block-amnesty-core-section.small,
-    .wp-block-html,
-    .video-block,
-    .card-image-text-block,
-    .read-more-block,
-    .slider-block,
-    div[data-test="contact-form"] p,
-    div[data-test="contact-form"] {
-      max-width: $container-md;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    .wp-block-image,
-    .image-block {
-      max-width: $container-lg;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    .custom-button-block {
-      max-width: $container-md;
-      margin-left: auto;
-      margin-right: auto;
-      margin-bottom: 0;
-    }
-
-    .call-to-action-block {
-      max-width: $container-lg;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    .wp-block-amnesty-core-chapo {
-      .text {
-        @media (min-width: $container-lg) {
-          width: 50%;
-          margin-left: 20%;
-        }
-      }
-    }
-
-    .interactive-map {
-      max-width: $container-hg;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    .carousel-block {
-      width: 100vw;
-      margin-left: calc(50% - 50vw);
-      margin-right: calc(50% - 50vw);
-
-      .swiper-slide {
-        max-width: none;
-      }
-    }
-  }
   }
 
   .page-hero-block {

--- a/private/src/styles/pages/page/type/_chronicle-promo.scss
+++ b/private/src/styles/pages/page/type/_chronicle-promo.scss
@@ -116,7 +116,7 @@
   }
 
   .related-posts-block {
-    margin-bottom: .6rem;
+    margin-bottom: 0.6rem;
     padding: 1rem 0 1rem 0;
 
     @media (min-width: $container-lg) {
@@ -125,7 +125,7 @@
 
     .content {
       .title {
-        padding: .5rem .7rem !important;
+        padding: 0.5rem 0.7rem !important;
         margin-bottom: 2.5rem !important;
 
         @media (min-width: $container-lg) {

--- a/private/src/styles/pages/page/type/_contact.scss
+++ b/private/src/styles/pages/page/type/_contact.scss
@@ -66,8 +66,8 @@
     .card-image-text-block,
     .read-more-block,
     .slider-block,
-    div[data-test="contact-form"],
-    div[data-test="contact-form"] p {
+    div[data-test='contact-form'],
+    div[data-test='contact-form'] p {
       max-width: $container-md;
       margin-left: auto;
       margin-right: auto;

--- a/private/src/styles/pages/page/type/_discover-chronicle.scss
+++ b/private/src/styles/pages/page/type/_discover-chronicle.scss
@@ -27,10 +27,12 @@
       }
     }
 
-    input:not([type="radio"]) {
+    input:not([type='radio']) {
       margin-bottom: 22px;
       border: 1px solid var(--wp--preset--color--grey-lighter);
-      transition: border 0.3s ease, margin-bottom 0.3s ease;
+      transition:
+        border 0.3s ease,
+        margin-bottom 0.3s ease;
 
       &.success {
         border: 2px solid var(--wp--preset--color--success);
@@ -74,7 +76,7 @@
         align-items: center;
         gap: 12px;
 
-        & > input[type="radio"] {
+        & > input[type='radio'] {
           cursor: pointer;
         }
 
@@ -154,7 +156,7 @@
   .discover-chronicle-legend > p {
     font-family: var(--wp--preset--font-family--primary);
     font-weight: lighter;
-    font-size: .625rem;
+    font-size: 0.625rem;
     line-height: 18px;
     letter-spacing: 0;
   }

--- a/private/src/styles/pages/page/type/_fondation.scss
+++ b/private/src/styles/pages/page/type/_fondation.scss
@@ -288,7 +288,7 @@
           margin-bottom: 30px;
         }
 
-        div[data-test="contact-form"] {
+        div[data-test='contact-form'] {
           box-shadow: none !important;
           margin-bottom: 0 !important;
 

--- a/private/src/styles/pages/page/type/_legs.scss
+++ b/private/src/styles/pages/page/type/_legs.scss
@@ -391,7 +391,7 @@
             margin-bottom: 30px;
           }
 
-          div[data-test="contact-form"] {
+          div[data-test='contact-form'] {
             box-shadow: none !important;
             margin-bottom: 0 !important;
 

--- a/private/src/styles/pages/page/type/_newsletter.scss
+++ b/private/src/styles/pages/page/type/_newsletter.scss
@@ -27,10 +27,12 @@
       }
     }
 
-    input:not([type="radio"]) {
+    input:not([type='radio']) {
       margin-bottom: 22px;
       border: 1px solid var(--wp--preset--color--grey-lighter);
-      transition: border 0.3s ease, margin-bottom 0.3s ease;
+      transition:
+        border 0.3s ease,
+        margin-bottom 0.3s ease;
 
       &.success {
         border: 2px solid var(--wp--preset--color--success);
@@ -70,7 +72,7 @@
         align-items: center;
         gap: 12px;
 
-        & > input[type="radio"] {
+        & > input[type='radio'] {
           cursor: pointer;
         }
 
@@ -147,7 +149,7 @@
   .newsletter-legend > p {
     font-family: var(--wp--preset--font-family--primary);
     font-weight: lighter;
-    font-size: .625rem;
+    font-size: 0.625rem;
     line-height: 18px;
     letter-spacing: 0;
   }
@@ -167,7 +169,6 @@
     &.success {
       border: 2px solid var(--wp--preset--color--grey-lighter);
       background-color: var(--wp--preset--color--grey-lighter);
-
     }
   }
 }

--- a/private/src/styles/pages/page/type/_standard.scss
+++ b/private/src/styles/pages/page/type/_standard.scss
@@ -151,8 +151,8 @@
     .card-image-text-block,
     .read-more-block,
     .slider-block,
-    div[data-test="contact-form"] p,
-    div[data-test="contact-form"] {
+    div[data-test='contact-form'] p,
+    div[data-test='contact-form'] {
       max-width: $container-md;
       margin-left: auto;
       margin-right: auto;

--- a/private/src/styles/pages/search/_additional-filters.scss
+++ b/private/src/styles/pages/search/_additional-filters.scss
@@ -1,6 +1,8 @@
 .horizontal-search .additional-filters {
   max-height: 0;
-  transition: max-height .3s, padding .3s;
+  transition:
+    max-height 0.3s,
+    padding 0.3s;
   overflow-y: hidden;
 }
 
@@ -80,7 +82,7 @@
 // no-js styles
 .no-js .horizontal-search .additional-filters {
   max-height: 1000px;
-  transition: max-height .3s;
+  transition: max-height 0.3s;
   padding: 0 0 var(--wp--preset--spacing--half) 0;
   overflow: visible;
 }

--- a/private/src/styles/pages/search/_initial-filters.scss
+++ b/private/src/styles/pages/search/_initial-filters.scss
@@ -51,7 +51,9 @@
   grid-column: 1 / span 13;
   order: 3;
   max-height: 0;
-  transition: max-height .3s, padding .3s;
+  transition:
+    max-height 0.3s,
+    padding 0.3s;
   overflow-y: hidden;
 
   @include mq(medium) {

--- a/private/src/styles/pages/search/_searchbox.scss
+++ b/private/src/styles/pages/search/_searchbox.scss
@@ -1,5 +1,5 @@
-@import "./initial-filters";
-@import "./additional-filters";
+@import './initial-filters';
+@import './additional-filters';
 
 .horizontal-search {
   margin-bottom: var(--wp--preset--spacing--single);
@@ -81,12 +81,12 @@
 
 .btn.toggle-search-filters .icon-arrow-down {
   @extend %icon-arrow-down-light;
-  transform: scale(.75);
-  transition: transform .3s;
+  transform: scale(0.75);
+  transition: transform 0.3s;
 }
 
 .btn.toggle-search-filters.is-expanded .icon-arrow-down {
-  transform: scale(.75) rotate(180deg);
+  transform: scale(0.75) rotate(180deg);
 }
 
 .horizontal-search .section.postlist-categoriesContainer {

--- a/private/src/styles/pages/search/results/_active-filters.scss
+++ b/private/src/styles/pages/search/results/_active-filters.scss
@@ -31,7 +31,7 @@
   font-size: var(--wp--preset--font-size--x-small);
 
   &::after {
-    content: "x";
+    content: 'x';
     display: inline-block;
     margin-left: var(--wp--preset--spacing--quarter);
   }

--- a/private/src/styles/utils/functions/_flexy.scss
+++ b/private/src/styles/utils/functions/_flexy.scss
@@ -1,4 +1,4 @@
-@use "sass:math";
+@use 'sass:math';
 
 $flexy-outer-gutter: $flexy-gutter-width !default;
 
@@ -43,10 +43,17 @@ $flexy-outer-gutter: $flexy-gutter-width !default;
 ///   width: calc(50% - 10px);
 /// }
 @mixin flexy-grid($noOfItems, $gutterWidth: $flexy-gutter-width) {
-  @if unit($gutterWidth) == "%" {
-    @include flexy-flex(#{math.div(100, $noOfItems) - math.div($gutterWidth * ($noOfItems - 1), $noOfItems)});
+  @if unit($gutterWidth) == '%' {
+    @include flexy-flex(
+      #{math.div(100, $noOfItems) - math.div($gutterWidth * ($noOfItems - 1), $noOfItems)}
+    );
   } @else {
-    @include flexy-flex(calc(#{math.div(100, $noOfItems) + "%"} - #{math.div($gutterWidth * ($noOfItems - 1), $noOfItems)}));
+    @include flexy-flex(
+      calc(
+        #{math.div(100, $noOfItems) + '%'} -
+          #{math.div($gutterWidth * ($noOfItems - 1), $noOfItems)}
+      )
+    );
   }
 }
 
@@ -67,7 +74,11 @@ $flexy-outer-gutter: $flexy-gutter-width !default;
 /// @param  {string} $outer-gutter - Outer Gutter
 /// @return {number}
 ///
-@function flexy-col($noOfColumns: 1, $containerWidth: $flexy-container, $outer-gutter: $flexy-outer-gutter) {
+@function flexy-col(
+  $noOfColumns: 1,
+  $containerWidth: $flexy-container,
+  $outer-gutter: $flexy-outer-gutter
+) {
   $col: math.div($flexy-column-width, ($containerWidth - 2 * $outer-gutter)) * 100;
   $gutter: flexy-gutter($containerWidth);
   $myValue: ($col * $noOfColumns) + ($gutter * ($noOfColumns - 1));

--- a/private/src/styles/utils/functions/_palette.scss
+++ b/private/src/styles/utils/functions/_palette.scss
@@ -14,7 +14,7 @@
 /// .block {
 ///   color: palette(brand, light);
 /// }
-@function palette($palette, $tone: "base") {
+@function palette($palette, $tone: 'base') {
   @if map-has-key($palettes, $palette) {
     @if map-has-key(map-get($palettes, $palette), $tone) {
       @return map-get(map-get($palettes, $palette), $tone);

--- a/private/src/styles/utils/helpers/_spacing.scss
+++ b/private/src/styles/utils/helpers/_spacing.scss
@@ -88,56 +88,119 @@ $spacing-paddings--zero: false !default;
 //
 // @example markup - Usage
 // <div class="u-mt"></div>
-$spacing-namespace: "u-" !default;
+$spacing-namespace: 'u-' !default;
 
 @if $spacing-helpers {
-
   //
   // Margins
   //
 
   // Standard margin
   @if $spacing-margins {
-    .#{$spacing-namespace}ma { margin:        $spacing-unit !important; }
-    .#{$spacing-namespace}mt { margin-top:    $spacing-unit !important; }
-    .#{$spacing-namespace}mr { margin-right:  $spacing-unit !important; }
-    .#{$spacing-namespace}mb { margin-bottom: $spacing-unit !important; }
-    .#{$spacing-namespace}ml { margin-left:   $spacing-unit !important; }
-    .#{$spacing-namespace}mh { margin-top:    $spacing-unit !important; margin-bottom: $spacing-unit !important; }
-    .#{$spacing-namespace}mv { margin-right:  $spacing-unit !important; margin-left:   $spacing-unit !important; }
+    .#{$spacing-namespace}ma {
+      margin: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}mt {
+      margin-top: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}mr {
+      margin-right: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}mb {
+      margin-bottom: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}ml {
+      margin-left: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}mh {
+      margin-top: $spacing-unit !important;
+      margin-bottom: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}mv {
+      margin-right: $spacing-unit !important;
+      margin-left: $spacing-unit !important;
+    }
   }
 
   // Double margin
   @if $spacing-margins--double {
-    .#{$spacing-namespace}ma\+ { margin:        $spacing-unit--double !important; }
-    .#{$spacing-namespace}mt\+ { margin-top:    $spacing-unit--double !important; }
-    .#{$spacing-namespace}mr\+ { margin-right:  $spacing-unit--double !important; }
-    .#{$spacing-namespace}mb\+ { margin-bottom: $spacing-unit--double !important; }
-    .#{$spacing-namespace}ml\+ { margin-left:   $spacing-unit--double !important; }
-    .#{$spacing-namespace}mh\+ { margin-top:    $spacing-unit--double !important; margin-bottom: $spacing-unit--double !important; }
-    .#{$spacing-namespace}mv\+ { margin-right:  $spacing-unit--double !important; margin-left:   $spacing-unit--double !important; }
+    .#{$spacing-namespace}ma\+ {
+      margin: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}mt\+ {
+      margin-top: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}mr\+ {
+      margin-right: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}mb\+ {
+      margin-bottom: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}ml\+ {
+      margin-left: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}mh\+ {
+      margin-top: $spacing-unit--double !important;
+      margin-bottom: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}mv\+ {
+      margin-right: $spacing-unit--double !important;
+      margin-left: $spacing-unit--double !important;
+    }
   }
 
   // Half margin
   @if $spacing-margins--half {
-    .#{$spacing-namespace}ma- { margin:        $spacing-unit--half !important; }
-    .#{$spacing-namespace}mt- { margin-top:    $spacing-unit--half !important; }
-    .#{$spacing-namespace}mr- { margin-right:  $spacing-unit--half !important; }
-    .#{$spacing-namespace}mb- { margin-bottom: $spacing-unit--half !important; }
-    .#{$spacing-namespace}ml- { margin-left:   $spacing-unit--half !important; }
-    .#{$spacing-namespace}mh- { margin-top:    $spacing-unit--half !important; margin-bottom: $spacing-unit--half !important; }
-    .#{$spacing-namespace}mv- { margin-right:  $spacing-unit--half !important; margin-left:   $spacing-unit--half !important; }
+    .#{$spacing-namespace}ma- {
+      margin: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}mt- {
+      margin-top: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}mr- {
+      margin-right: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}mb- {
+      margin-bottom: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}ml- {
+      margin-left: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}mh- {
+      margin-top: $spacing-unit--half !important;
+      margin-bottom: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}mv- {
+      margin-right: $spacing-unit--half !important;
+      margin-left: $spacing-unit--half !important;
+    }
   }
 
   // Zero margin
   @if $spacing-margins--zero {
-    .#{$spacing-namespace}ma0 { margin:        0 !important; }
-    .#{$spacing-namespace}mt0 { margin-top:    0 !important; }
-    .#{$spacing-namespace}mr0 { margin-right:  0 !important; }
-    .#{$spacing-namespace}mb0 { margin-bottom: 0 !important; }
-    .#{$spacing-namespace}ml0 { margin-left:   0 !important; }
-    .#{$spacing-namespace}mh0 { margin-top:    0 !important; margin-bottom: 0 !important; }
-    .#{$spacing-namespace}mv0 { margin-right:  0 !important; margin-left:   0 !important; }
+    .#{$spacing-namespace}ma0 {
+      margin: 0 !important;
+    }
+    .#{$spacing-namespace}mt0 {
+      margin-top: 0 !important;
+    }
+    .#{$spacing-namespace}mr0 {
+      margin-right: 0 !important;
+    }
+    .#{$spacing-namespace}mb0 {
+      margin-bottom: 0 !important;
+    }
+    .#{$spacing-namespace}ml0 {
+      margin-left: 0 !important;
+    }
+    .#{$spacing-namespace}mh0 {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+    .#{$spacing-namespace}mv0 {
+      margin-right: 0 !important;
+      margin-left: 0 !important;
+    }
   }
 
   //
@@ -146,45 +209,109 @@ $spacing-namespace: "u-" !default;
 
   // Base padding
   @if $spacing-paddings {
-    .#{$spacing-namespace}pa { padding:        $spacing-unit !important; }
-    .#{$spacing-namespace}pt { padding-top:    $spacing-unit !important; }
-    .#{$spacing-namespace}pr { padding-right:  $spacing-unit !important; }
-    .#{$spacing-namespace}pb { padding-bottom: $spacing-unit !important; }
-    .#{$spacing-namespace}pl { padding-left:   $spacing-unit !important; }
-    .#{$spacing-namespace}ph { padding-top:    $spacing-unit !important; padding-bottom: $spacing-unit !important; }
-    .#{$spacing-namespace}pv { padding-right:  $spacing-unit !important; padding-left:   $spacing-unit !important; }
+    .#{$spacing-namespace}pa {
+      padding: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}pt {
+      padding-top: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}pr {
+      padding-right: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}pb {
+      padding-bottom: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}pl {
+      padding-left: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}ph {
+      padding-top: $spacing-unit !important;
+      padding-bottom: $spacing-unit !important;
+    }
+    .#{$spacing-namespace}pv {
+      padding-right: $spacing-unit !important;
+      padding-left: $spacing-unit !important;
+    }
   }
 
   // Double padding
   @if $spacing-paddings--double {
-    .#{$spacing-namespace}pa\+ { padding:        $spacing-unit--double !important; }
-    .#{$spacing-namespace}pt\+ { padding-top:    $spacing-unit--double !important; }
-    .#{$spacing-namespace}pr\+ { padding-right:  $spacing-unit--double !important; }
-    .#{$spacing-namespace}pb\+ { padding-bottom: $spacing-unit--double !important; }
-    .#{$spacing-namespace}pl\+ { padding-left:   $spacing-unit--double !important; }
-    .#{$spacing-namespace}ph\+ { padding-top:    $spacing-unit--double !important; padding-bottom: $spacing-unit--double !important; }
-    .#{$spacing-namespace}pv\+ { padding-right:  $spacing-unit--double !important; padding-left:   $spacing-unit--double !important; }
+    .#{$spacing-namespace}pa\+ {
+      padding: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}pt\+ {
+      padding-top: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}pr\+ {
+      padding-right: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}pb\+ {
+      padding-bottom: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}pl\+ {
+      padding-left: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}ph\+ {
+      padding-top: $spacing-unit--double !important;
+      padding-bottom: $spacing-unit--double !important;
+    }
+    .#{$spacing-namespace}pv\+ {
+      padding-right: $spacing-unit--double !important;
+      padding-left: $spacing-unit--double !important;
+    }
   }
 
   // Half padding
   @if $spacing-paddings--half {
-    .#{$spacing-namespace}pa- { padding:        $spacing-unit--half !important; }
-    .#{$spacing-namespace}pt- { padding-top:    $spacing-unit--half !important; }
-    .#{$spacing-namespace}pr- { padding-right:  $spacing-unit--half !important; }
-    .#{$spacing-namespace}pb- { padding-bottom: $spacing-unit--half !important; }
-    .#{$spacing-namespace}pl- { padding-left:   $spacing-unit--half !important; }
-    .#{$spacing-namespace}ph- { padding-top:    $spacing-unit--half !important; padding-bottom: $spacing-unit--half !important; }
-    .#{$spacing-namespace}pv- { padding-right:  $spacing-unit--half !important; padding-left:   $spacing-unit--half !important; }
+    .#{$spacing-namespace}pa- {
+      padding: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}pt- {
+      padding-top: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}pr- {
+      padding-right: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}pb- {
+      padding-bottom: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}pl- {
+      padding-left: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}ph- {
+      padding-top: $spacing-unit--half !important;
+      padding-bottom: $spacing-unit--half !important;
+    }
+    .#{$spacing-namespace}pv- {
+      padding-right: $spacing-unit--half !important;
+      padding-left: $spacing-unit--half !important;
+    }
   }
 
   // Zero padding
   @if $spacing-paddings--zero {
-    .#{$spacing-namespace}pa0 { padding:        0 !important; }
-    .#{$spacing-namespace}pt0 { padding-top:    0 !important; }
-    .#{$spacing-namespace}pr0 { padding-right:  0 !important; }
-    .#{$spacing-namespace}pb0 { padding-bottom: 0 !important; }
-    .#{$spacing-namespace}pl0 { padding-left:   0 !important; }
-    .#{$spacing-namespace}ph0 { padding-top:    0 !important; padding-bottom: 0 !important; }
-    .#{$spacing-namespace}pv0 { padding-right:  0 !important; padding-left:   0 !important; }
+    .#{$spacing-namespace}pa0 {
+      padding: 0 !important;
+    }
+    .#{$spacing-namespace}pt0 {
+      padding-top: 0 !important;
+    }
+    .#{$spacing-namespace}pr0 {
+      padding-right: 0 !important;
+    }
+    .#{$spacing-namespace}pb0 {
+      padding-bottom: 0 !important;
+    }
+    .#{$spacing-namespace}pl0 {
+      padding-left: 0 !important;
+    }
+    .#{$spacing-namespace}ph0 {
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+    }
+    .#{$spacing-namespace}pv0 {
+      padding-right: 0 !important;
+      padding-left: 0 !important;
+    }
   }
 }

--- a/private/src/styles/utils/mixins/_clearfix.scss
+++ b/private/src/styles/utils/mixins/_clearfix.scss
@@ -16,7 +16,7 @@
 @mixin clearfix {
   &::before,
   &::after {
-    content: "";
+    content: '';
     display: table;
     clear: both;
   }

--- a/private/src/styles/utils/mixins/_states.scss
+++ b/private/src/styles/utils/mixins/_states.scss
@@ -1,5 +1,5 @@
 @mixin state-background($colour: var(--wp--preset--color--black)) {
-  transition: background-color .3s ease-in-out;
+  transition: background-color 0.3s ease-in-out;
 
   &:hover,
   &:active,
@@ -13,7 +13,7 @@
 }
 
 @mixin state-foreground($colour: var(--wp--preset--color--black)) {
-  transition: color .3s ease-in-out;
+  transition: color 0.3s ease-in-out;
 
   &:hover,
   &:active,

--- a/private/src/styles/utils/variables/_breakpoints.scss
+++ b/private/src/styles/utils/variables/_breakpoints.scss
@@ -1,19 +1,19 @@
 // This file uses spacing to align, disable disalowing more than 1 space after colon.
 
 $mq-breakpoints: (
-  xxx-small:   320px,
-  xx-small:    465px,
-  x-small:     540px,
-  xm-small:    570px,
-  md-small:    596px,
-  small:       760px,
+  xxx-small: 320px,
+  xx-small: 465px,
+  x-small: 540px,
+  xm-small: 570px,
+  md-small: 596px,
+  small: 760px,
   wp-adminbar: 781px,
-  medium-sm:   840px,
-  medium:      940px,
-  medium-lg:   988px,
-  mobile-nav:  1024px,
-  large:       1110px,
-  x-large:     1200px,
-  xm-large:    1320px,
-  xx-large:    1400px
+  medium-sm: 840px,
+  medium: 940px,
+  medium-lg: 988px,
+  mobile-nav: 1024px,
+  large: 1110px,
+  x-large: 1200px,
+  xm-large: 1320px,
+  xx-large: 1400px,
 );

--- a/private/src/styles/utils/variables/_grid-settings.scss
+++ b/private/src/styles/utils/variables/_grid-settings.scss
@@ -6,9 +6,9 @@
 ////
 
 // Adds support for flexygrids
-$flexy-container:    1468px !default;
-$flexy-columns:      12     !default;
-$flexy-column-width: 92px  !default;
-$flexy-gutter-width: 28px   !default;
-$flexy-outer-gutter: 0px   !default;
+$flexy-container: 1468px !default;
+$flexy-columns: 12 !default;
+$flexy-column-width: 92px !default;
+$flexy-gutter-width: 28px !default;
+$flexy-outer-gutter: 0px !default;
 /* stylelint-enable */

--- a/private/src/styles/woocommerce/_my-account.scss
+++ b/private/src/styles/woocommerce/_my-account.scss
@@ -3,7 +3,9 @@
 }
 
 .page-template-my-account .linkList li {
-  transition: background-color .3s ease-in-out, color .3s ease-in-out;
+  transition:
+    background-color 0.3s ease-in-out,
+    color 0.3s ease-in-out;
 
   &:first-child {
     border-top: 1px solid var(--wp--preset--color--grey-lighter);

--- a/private/src/styles/woocommerce/_product-single.scss
+++ b/private/src/styles/woocommerce/_product-single.scss
@@ -3,7 +3,7 @@
 }
 
 .single-product a.remove {
-  line-height: .85em;
+  line-height: 0.85em;
 }
 
 .single-product .woocommerce-ordering {

--- a/private/tests/e2e/support/turnstile.mjs
+++ b/private/tests/e2e/support/turnstile.mjs
@@ -100,11 +100,13 @@ export const mockSilentTurnstile = async (page) =>
   routeTurnstileApi(page, { mode: 'silent', delay: 0, token: '', trigger: 'render' });
 
 export const expectTurnstileScriptsInHead = async (page, expect) => {
-  const scriptOrder = await page.locator('head script[src]').evaluateAll((scripts) =>
-    scripts.map((script) => script.getAttribute('src')),
-  );
+  const scriptOrder = await page
+    .locator('head script[src]')
+    .evaluateAll((scripts) => scripts.map((script) => script.getAttribute('src')));
 
-  const localGuardIndex = scriptOrder.findIndex((src) => src.includes('/assets/scripts/turnstile.js'));
+  const localGuardIndex = scriptOrder.findIndex((src) =>
+    src.includes('/assets/scripts/turnstile.js'),
+  );
   const cloudflareIndex = scriptOrder.findIndex((src) =>
     src.includes('https://challenges.cloudflare.com/turnstile/v0/api.js'),
   );

--- a/private/tests/e2e/turnstile-cloudflare-dummy.spec.mjs
+++ b/private/tests/e2e/turnstile-cloudflare-dummy.spec.mjs
@@ -45,7 +45,9 @@ test.describe('@cloudflare-smoke Turnstile dummy keys', () => {
     await page.getByLabel('Votre email (obligatoire) :').fill(UNKNOWN_EMAIL);
     await page.locator('#submit-btn').click();
 
-    await expect(page.getByText('La vérification de sécurité a échoué.', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText('La vérification de sécurité a échoué.', { exact: true }),
+    ).toBeVisible();
     await expect(page.getByText('Votre utilisateur nous est inconnu')).toHaveCount(0);
   });
 });

--- a/private/tests/e2e/turnstile-forgot-password-flow.spec.mjs
+++ b/private/tests/e2e/turnstile-forgot-password-flow.spec.mjs
@@ -3,22 +3,28 @@ import { mockSuccessfulTurnstile } from './support/turnstile.mjs';
 
 const FORGOT_PASSWORD_PATH = '/mot-de-passe-oublie/';
 
-const setServerSideTurnstileResult = async (page, { success, error = 'invalid-input-response' }) => {
-  await page.locator('form.aif-form-container').evaluate((form, options) => {
-    const appendHiddenInput = (name, value) => {
-      const input = document.createElement('input');
-      input.type = 'hidden';
-      input.name = name;
-      input.value = value;
-      form.appendChild(input);
-    };
+const setServerSideTurnstileResult = async (
+  page,
+  { success, error = 'invalid-input-response' },
+) => {
+  await page.locator('form.aif-form-container').evaluate(
+    (form, options) => {
+      const appendHiddenInput = (name, value) => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.value = value;
+        form.appendChild(input);
+      };
 
-    appendHiddenInput('aif_e2e_turnstile_verify_success', options.success ? '1' : '0');
+      appendHiddenInput('aif_e2e_turnstile_verify_success', options.success ? '1' : '0');
 
-    if (!options.success) {
-      appendHiddenInput('aif_e2e_turnstile_verify_error', options.error);
-    }
-  }, { success, error });
+      if (!options.success) {
+        appendHiddenInput('aif_e2e_turnstile_verify_error', options.error);
+      }
+    },
+    { success, error },
+  );
 };
 
 const submitForgotPasswordForm = async (page, email = 'unknown@example.org') => {
@@ -54,7 +60,9 @@ test.describe('forgot password Turnstile server-side flow', () => {
     });
     await submitForgotPasswordForm(page);
 
-    await expect(page.getByText('La vérification de sécurité a échoué.', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText('La vérification de sécurité a échoué.', { exact: true }),
+    ).toBeVisible();
     await expect(page.getByText('Votre utilisateur nous est inconnu')).toHaveCount(0);
   });
 });

--- a/private/tests/e2e/turnstile-guard.spec.mjs
+++ b/private/tests/e2e/turnstile-guard.spec.mjs
@@ -135,9 +135,7 @@ test('shows a failure message when Turnstile never creates a token', async ({
   await fillForgottenPasswordForm(page);
   await page.locator('#submit-btn').click();
 
-  await expect(page.getByRole('alert')).toContainText(
-    'La vérification de sécurité est en cours',
-  );
+  await expect(page.getByRole('alert')).toContainText('La vérification de sécurité est en cours');
   await expect(page.getByRole('alert')).toContainText(
     'La vérification de sécurité n’a pas pu être effectuée',
     { timeout: 5000 },


### PR DESCRIPTION
## Why

- Add a repeatable frontend formatting command.
- Keep formatter configuration separate from the mechanical formatting baseline.
- Prevent generated reports, caches, and build outputs from being formatted.

## What changed

- Add `yarn format` using `prettier --write .` from `private/`.
- Add a local `.prettierignore` for generated outputs and caches.
- Align Stylelint with Prettier output for SCSS formatting rules.
- Apply the Prettier formatting baseline to frontend sources and E2E test files.

## Validation

- `yarn format`
- `git diff --check`
- `yarn lint`