### PR TITLE
docs: document project and E2E setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Ceci est le dépôt de la refonte du site web d'Amnesty International France bas
 
 This is the repository for the redesign of the Amnesty International France website based on [humanity theme](https://github.com/amnestywebsite/humanity-theme) [(README)](./README_humanity.md). The repository contains all the elements required to run the site, including specific plugins.
 
+## Documentation
+
+- [Architecture overview](./docs/ARCHITECTURE.md)
+- [Main theme](./wp-content/themes/humanity-theme/README.md)
+- [Frontend toolchain](./private/README.md)
+- [Playwright E2E tests](./private/tests/e2e/README.md)
+- [AIF Donor Space plugin](./wp-content/plugins/aif-donor-space/README.md)
+
 ## Requirements
 
 - Ask for the `.env` file

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,213 @@
+# Architecture
+
+This document provides a concise overview of the Amnesty International France
+website architecture. It is intended as an entry point before more detailed
+documentation is written for each module, theme, plugin, or subsystem.
+
+## Overview
+
+The project is a full WordPress application. The repository versions WordPress
+core, the main theme, several third-party plugins, project-specific plugins,
+frontend build tooling, installation scripts, and deployment scripts.
+
+The main building blocks are:
+
+- [`wp-content/themes/humanity-theme`](../wp-content/themes/humanity-theme/README.md):
+  the main site theme, derived from Amnesty International's Humanity theme and
+  heavily adapted for Amnesty France needs.
+- [`private`](../private/README.md): frontend sources, Webpack/Yarn
+  configuration, JS/SCSS linting, frontend tests, and theme asset generation.
+- [`wp-content/plugins/aif-donor-space`](../wp-content/plugins/aif-donor-space/README.md):
+  business plugin for the donor space and part of the authenticated user area.
+- `wp-content/plugins/aif-rss-importer`: RSS import plugin for press releases.
+- `wp-content/plugins/prismic-migration`: Prismic migration plugin exposed
+  through WP-CLI.
+- `wp-content/plugins/interactive-map`: custom Gutenberg block based on Leaflet.
+- `clevercloud`, `infogerance`, `.github/workflows`: installation, hosting,
+  backup, and deployment scripts.
+
+## WordPress Runtime
+
+The site runs on WordPress, PHP, MySQL/MariaDB, and WP-CLI. Public pages,
+archives, editorial pages, forms, and authenticated areas are rendered by
+WordPress through a mix of block templates, PHP patterns, and classic PHP
+templates.
+
+The repository also contains several third-party plugins required by the site or
+the back office:
+
+- Advanced Custom Fields
+- CMB2 and CMB2 extensions
+- Jetpack
+- The Events Calendar
+- Yoast SEO
+- Cloudflare
+
+The theme and project plugins add custom post types, taxonomies, REST endpoints,
+WP-CLI commands, and business tables on top of the standard WordPress data
+model.
+
+## Main Theme
+
+The `humanity-theme` theme is the main integration point for the site. It
+contains:
+
+- Full Site Editing templates in `templates/*.html`;
+- template parts in `parts/*.html`;
+- PHP block patterns in `patterns/*.php`;
+- specific PHP templates for login and `Mon Espace` pages;
+- PHP-rendered blocks in `includes/blocks`;
+- post type, taxonomy, REST API, SEO, search, Salesforce, petition, urgent
+  action, and plugin integration code.
+
+Assets consumed by the theme are generated into
+`wp-content/themes/humanity-theme/assets` from the `private` source tree.
+
+## Frontend And Assets
+
+The `private` directory contains the theme frontend toolchain:
+
+- Webpack to compile scripts and styles;
+- Yarn for dependency management;
+- Sass/PostCSS for styles;
+- ESLint and Stylelint for frontend quality checks;
+- Vitest for frontend tests;
+- TypeScript in targeted `checkJs` mode for selected JavaScript modules.
+
+The main Webpack entries are:
+
+- `bundle`: global frontend application for the theme;
+- `turnstile`: dedicated client guard for forms protected by Turnstile;
+- `blocks`: Gutenberg editor/block code;
+- `editor`: editor styles and behavior;
+- `admin`: back-office assets.
+
+The build writes directly to versioned theme assets:
+
+- `wp-content/themes/humanity-theme/assets/scripts`
+- `wp-content/themes/humanity-theme/assets/styles`
+- `wp-content/themes/humanity-theme/assets/images`
+
+## Custom Plugins
+
+### [`aif-donor-space`](../wp-content/plugins/aif-donor-space/README.md)
+
+Business plugin for the donor space and part of the authenticated user area. It
+creates or ensures the presence of critical pages, loads its own assets, and
+organizes the domain around:
+
+- user authentication;
+- two-factor authentication;
+- bank details;
+- contact preferences;
+- tax receipts;
+- Salesforce calls;
+- email delivery through Mailgun.
+
+### `aif-rss-importer`
+
+RSS import plugin configurable from the WordPress admin. It imports external
+content into the `press-release` post type and schedules imports through
+WP-Cron.
+
+### `prismic-migration`
+
+Tooling plugin for migrating Prismic content into WordPress. It exposes WP-CLI
+commands, including migration by content type and post-import link repair.
+
+### `interactive-map`
+
+Custom Gutenberg block plugin. It has its own build based on `@wordpress/scripts`
+and uses Leaflet for map rendering.
+
+## Business Data
+
+In addition to standard WordPress tables, the project creates specific business
+tables:
+
+- `wp_aif_users`: local signer/business user data;
+- `wp_aif_petitions_signatures`: petition signatures and Salesforce sync state;
+- `wp_aif_urgent_action`: urgent action registrations and sync state.
+
+Editorial and business content is structured with several custom post types and
+taxonomies, including:
+
+- post types: `petition`, `document`, `newsletter`, `chronique`, `edh`,
+  `training`, `press-release`, `local-structures`, `sidebar`, `pop-in`;
+- taxonomies: `combat`, `location`, `keyword`, `document_type`,
+  `document_democratic_type`, `document_instance_type`,
+  `document_militant_type`.
+
+## External Integrations
+
+The project communicates with several external services:
+
+- Salesforce: OAuth client credentials, REST API, and Bulk API for petitions,
+  users, newsletters, cases, and urgent actions;
+- Mailgun: email delivery for the donor space and verification flows;
+- Cloudflare Turnstile: security verification for sensitive forms;
+- Prismic: historical content source used during migration;
+- Amnesty.org RSS: source for imported press releases;
+- Google Geocoding: local structure search/geocoding;
+- Google Tag Manager, Google Analytics, Hotjar, and VWO: analytics and tracking.
+
+Expected environment variables are documented in `.env.example` and completed by
+the `getenv()` calls in the application code.
+
+## Forms And Security
+
+Several public and authenticated forms interact with Salesforce, Mailgun, local
+tables, and Turnstile. Forms protected by Turnstile use a custom theme
+integration:
+
+- HTML widget rendering in the relevant templates/patterns;
+- local `turnstile.js` script loaded before the Cloudflare API;
+- server-side validation through `siteverify`;
+- error messages adapted to the invisible Turnstile mode.
+
+Sensitive REST endpoints rely on WordPress permissions, REST nonces, or the
+current authentication state depending on the use case.
+
+## Environments
+
+The project supports several local and remote workflows:
+
+- historical installation through Castor and WP-CLI;
+- local WordPress environment through `private/.wp-env.json`;
+- local MySQL/MariaDB database;
+- `.env`-based configuration;
+- historical Clever Cloud deployment;
+- production deployment through GitHub Actions on the `prod` branch.
+
+The Clever Cloud file `infogerance/aif-clever-cloud.php` generates a WordPress
+configuration from platform environment variables.
+
+## Quality And CI
+
+Available checks are:
+
+- PHP-CS-Fixer through `composer run cs`;
+- PHPStan through `composer run analyse`;
+- PHPCS through `composer lint`;
+- Actionlint for GitHub workflows;
+- ESLint through `yarn lint:scripts`;
+- Stylelint through `yarn lint:styles`;
+- Webpack through `yarn build` or `yarn build:prod`;
+- Vitest through `yarn test`;
+- targeted Turnstile typecheck through `yarn typecheck:turnstile`.
+
+The current GitHub CI runs PHP checks and GitHub Actions linting. Frontend
+checks exist locally but are not yet covered by the main CI workflow.
+
+## Documentation Map
+
+This file should remain a high-level overview. Subsystem documentation should
+live next to the code it describes when possible. Current subsystem documents:
+
+- [`wp-content/themes/humanity-theme`](../wp-content/themes/humanity-theme/README.md):
+  theme, templates, patterns, blocks, hooks, post types, taxonomies, and
+  integrations;
+- [`private`](../private/README.md): frontend build, assets, JS/SCSS
+  conventions, tests, and typecheck;
+- [`wp-content/plugins/aif-donor-space`](../wp-content/plugins/aif-donor-space/README.md):
+  donor space, pages, data, Salesforce, Mailgun, and REST API;

--- a/private/README.md
+++ b/private/README.md
@@ -1,0 +1,257 @@
+# Frontend Toolchain
+
+This document describes the `private` subsystem: frontend sources, asset
+generation, local WordPress tooling, and frontend quality checks.
+
+## Role
+
+`private` is the source of truth for the main theme frontend assets. It contains:
+
+- JavaScript modules used by the public site, editor, admin, and Turnstile forms;
+- SCSS sources for theme, editor, admin, blocks, `Mon Espace`, WooCommerce, and
+  shared components;
+- static images, fonts, and frontend-only assets;
+- Webpack, Babel, PostCSS, ESLint, Stylelint, Vitest, TypeScript, Yarn, and
+  `wp-env` configuration;
+- helper scripts used by local installation, linting, translation, and external
+  test workflows.
+
+The generated runtime assets are written into
+`wp-content/themes/humanity-theme/assets`. When frontend source changes affect
+the browser output, the corresponding built assets should be regenerated and
+committed with the source changes.
+
+## Directory Layout
+
+Important directories and files:
+
+- `src/scripts/`: JavaScript entry points and modules.
+- `src/scripts/modules/`: public-site behavior modules initialized by
+  `App.js`, plus the dedicated Turnstile form guard module.
+- `src/scripts/editor/`: Gutenberg block registrations, editor plugins, block
+  styles, and editor-side behavior.
+- `src/scripts/admin/`: WordPress admin behavior.
+- `src/styles/`: SCSS entry points and partials.
+- `src/static/`: static assets copied to the theme asset directory.
+- `tests/`: Vitest tests. The current coverage is focused on Turnstile.
+- `webpack.config.js`: frontend build configuration.
+- `package.json` and `yarn.lock`: frontend dependency graph and scripts.
+- `tsconfig.json`: targeted JavaScript type checking configuration.
+- `.wp-env.json`: local WordPress environment definition.
+- `bin/`: helper scripts for install, lint, translations, and external tests.
+
+## Runtime Boundary
+
+`private` is not loaded by WordPress directly. WordPress consumes the generated
+files from:
+
+- `wp-content/themes/humanity-theme/assets/scripts`;
+- `wp-content/themes/humanity-theme/assets/styles`;
+- `wp-content/themes/humanity-theme/assets/images`;
+- `wp-content/themes/humanity-theme/assets/fonts`.
+
+The theme enqueues those generated files from PHP. This means changes under
+`private/src` are incomplete until the relevant Webpack build has been run.
+
+## Build Pipeline
+
+The build is custom Webpack tooling, not `@wordpress/scripts`.
+
+Main commands from `private/package.json`:
+
+- `yarn build:dev`: development build;
+- `yarn build:prod`: production build;
+- `yarn build`: production build alias;
+- `yarn build:static`: static asset copy build;
+- `yarn watch:dev`: development watch mode;
+- `yarn watch:prod`: production watch mode;
+- `yarn watch`: watch alias.
+
+Webpack compiles from `private/src` and writes into
+`../wp-content/themes/humanity-theme/assets`. The output path is relative to the
+`private` directory.
+
+The build stack includes:
+
+- Webpack 5 for bundling;
+- `esbuild-loader` for JavaScript transpilation and production minification;
+- Babel configuration for legacy syntax support and React JSX transforms;
+- Sass, PostCSS, Autoprefixer, and `postcss-pxtorem` for styles;
+- `mini-css-extract-plugin` for CSS extraction;
+- `copy-webpack-plugin` for static assets;
+- `@svgr/webpack` for imported SVG components.
+
+The configured Node version is `v20.9.0`. Yarn uses the `node-modules` linker.
+
+## Webpack Entries
+
+The main entries are:
+
+- `bundle`: public-site application, sourced from `src/scripts/App.js`.
+- `turnstile`: standalone Turnstile client guard, sourced from
+  `src/scripts/turnstile.js`.
+- `blocks`: Gutenberg block/editor registrations, sourced from
+  `src/scripts/blocks.js`.
+- `editor`: editor styles, sourced from `src/scripts/editor.js`.
+- `admin`: admin scripts and styles, sourced from `src/scripts/admin.js`.
+
+The build supports `--env entry=<name>` to compile one entry. `--env entry=static`
+runs only the static asset copy path.
+
+JavaScript files are emitted under `assets/scripts`. Extracted CSS is emitted
+under `assets/styles`.
+
+## JavaScript Architecture
+
+`src/scripts/App.js` is the main public frontend application. It imports
+`src/styles/app.scss`, frontend polyfills, and all public interaction modules,
+then initializes them in a single `App()` function.
+
+The application is exposed to `window.App.default()` through Webpack
+`expose-loader`. The theme calls that global from footer inline JavaScript after
+the generated `bundle` script has been enqueued.
+
+Common public modules handle:
+
+- navigation, headers, overlays, pop-ins, language selectors, and banners;
+- filters, sliders, tabs, carousels, and table-of-contents behavior;
+- petition, urgent action, newsletter, donation, and Jetpack form behavior;
+- `Mon Espace` menus and mobile interactions;
+- share, tracking feedback, localization, iframes, and responsive helpers.
+
+The `turnstile` entry is intentionally separate from `bundle`. It must be loaded
+before the Cloudflare Turnstile API script so global callbacks and submit guards
+exist before Cloudflare renders or validates protected forms.
+
+Webpack externals assume these globals are provided by WordPress or the theme:
+
+- `lodash`;
+- `React`;
+- `ReactDOM`;
+- `wp.i18n`.
+
+## Styles Architecture
+
+The main SCSS entry is `src/styles/app.scss`. It imports the project styling in
+this broad order:
+
+- design variables, grid settings, functions, and mixins;
+- vendor styles such as Flickity;
+- base resets, typography, images, containers, overlays, and Jetpack forms;
+- layout partials for header, navigation, footer, hero, and banners;
+- components such as lists, media, social links, forms, grids, modals, filters,
+  donation tools, and back-to-top controls;
+- `Mon Espace` styles;
+- block and core-block styles;
+- block pattern styles;
+- page-specific styles;
+- WooCommerce styles;
+- utility helper classes;
+- import-specific styles.
+
+Additional SCSS entries are:
+
+- `admin.scss`: admin interface styles;
+- `editor.scss`: editor styles;
+- `gutenberg.scss`: Gutenberg block/editor styles loaded by the `blocks` entry.
+
+Webpack sets `css-loader` with `url: false`, so asset URLs inside CSS are not
+rewritten by the loader. Static images and fonts are copied from `src/static`.
+
+## Local WordPress Environment
+
+`private/.wp-env.json` defines a local WordPress environment with:
+
+- the project theme mounted from `../wp-content/themes/humanity-theme`;
+- CMB2 and CMB2-related plugins installed from WordPress.org or GitHub;
+- an `afterStart` lifecycle script that activates `humanity-theme`.
+
+The package script `yarn env` delegates to `@wordpress/env` through `yarn dlx`.
+This is local environment tooling only; the main frontend build does not use
+`@wordpress/scripts`.
+
+## Tests And Type Checking
+
+Current frontend checks include:
+
+- `yarn test`: runs Vitest in `jsdom`;
+- `yarn test:e2e`: runs Playwright end-to-end tests against the local WordPress
+  E2E environment;
+- `yarn typecheck:turnstile`: runs TypeScript in `allowJs`/`checkJs` mode for
+  `src/scripts/modules/turnstile.js`.
+
+The Vitest configuration includes `tests/**/*.test.js`. The current tests are
+scoped to the Turnstile module.
+
+The TypeScript configuration is intentionally narrow. It enables strict checking
+for the Turnstile module without converting the broader JavaScript codebase to
+TypeScript.
+
+Playwright tests live under `tests/e2e`. They use `tests/e2e/.wp-env.e2e.json`
+and a local-only E2E support plugin that provides Cloudflare Turnstile dummy
+keys for the WordPress test environment on `http://localhost:8898`.
+Deterministic tests mock Cloudflare's API script and run on every PR. The real
+Cloudflare dummy-key smoke test is opt-in:
+
+```bash
+yarn env:e2e:start
+./tests/e2e/support/seed-wordpress.sh
+yarn test:e2e
+RUN_CLOUDFLARE_SMOKE=1 yarn test:e2e tests/e2e/turnstile-cloudflare-dummy.spec.mjs
+yarn env:e2e:stop
+```
+
+Before running E2E tests for the first time, install Chromium:
+
+```bash
+yarn playwright install chromium
+```
+
+## Linting And Formatting
+
+Main quality commands:
+
+- `yarn lint:scripts`: ESLint over `src/`;
+- `yarn lint:styles`: Stylelint over `src/**/*.scss`;
+- `yarn lint`: runs script and style linting;
+- `yarn prettier --write <paths>`: applies the configured Prettier formatting
+  when formatting changes are needed.
+
+ESLint uses Airbnb base rules, React rules, WordPress i18n rules, and Prettier.
+Stylelint uses SCSS rules and project-specific exceptions.
+
+## Helper Scripts
+
+The `bin/` directory contains shell helpers:
+
+- `install.sh`: Composer install, Node setup through `nvm`, Corepack activation,
+  and Yarn install under `private`;
+- `lint.sh`: Composer linting, frontend linting, and optional shell linting;
+- `lang.sh`: translation file update workflow;
+- `run-tests.sh`: Ghost Inspector CLI workflow.
+
+These scripts are operational helpers rather than WordPress runtime code.
+
+## Change Conventions
+
+When changing frontend behavior:
+
+- edit source files under `private/src`, not generated files first;
+- rebuild the affected Webpack entry and include generated theme assets when
+  they change;
+- keep generated asset diffs scoped to the related source change;
+- keep Turnstile code in the dedicated `turnstile` entry when the code must run
+  before the Cloudflare API;
+- avoid migrating this build to `@wordpress/scripts` unless that decision is
+  made explicitly for the whole subsystem;
+- run the smallest relevant checks first, then broaden checks when touching
+  shared entries such as `bundle` or `app.scss`.
+
+Recommended checks by change type:
+
+- Turnstile changes: `yarn test`, `yarn typecheck:turnstile`,
+  `yarn test:e2e --grep-invert @cloudflare-smoke`, and the relevant Webpack
+  build;
+- JavaScript module changes: `yarn lint:scripts` and the relevant Webpack build;
+- SCSS changes: `yarn lint:styles` and the relevant Webpack build;
+- shared entry changes: `yarn lint`, `yarn test`, and `yarn build:prod`.

--- a/private/tests/e2e/README.md
+++ b/private/tests/e2e/README.md
@@ -1,0 +1,139 @@
+# Playwright E2E Tests
+
+This directory contains the Playwright end-to-end setup for the frontend
+behaviors that need a running WordPress site. The current suite focuses on the
+Cloudflare Turnstile integration introduced for protected forms.
+
+## Layout
+
+- `.wp-env.e2e.json`: dedicated `wp-env` configuration for E2E tests.
+- `support/seed-wordpress.sh`: seeds the minimal WordPress content required by
+  the tests.
+- `support/turnstile.mjs`: deterministic Playwright helpers and Cloudflare
+  Turnstile mocks.
+- `wordpress/aif-e2e-support/`: local-only WordPress plugin for the E2E
+  environment. It provides Turnstile dummy keys and small stubs for dependencies
+  that are not relevant to these tests.
+- `turnstile-guard.spec.mjs`: deterministic regression tests for the local
+  Turnstile guard.
+- `turnstile-cloudflare-dummy.spec.mjs`: opt-in smoke tests using Cloudflare's
+  official dummy Turnstile keys.
+
+## Installation
+
+Run commands from `private/`.
+
+```bash
+yarn install --immutable
+yarn playwright install chromium
+```
+
+On Linux CI runners or fresh machines that miss browser system dependencies,
+use:
+
+```bash
+yarn playwright install --with-deps chromium
+```
+
+## WordPress E2E Environment
+
+The E2E environment is isolated from the default local `wp-env` setup:
+
+- config file: `tests/e2e/.wp-env.e2e.json`;
+- site URL: `http://localhost:8898`;
+- tests environment: disabled with `testsEnvironment: false`;
+- support plugin: `tests/e2e/wordpress/aif-e2e-support`;
+- theme: `../wp-content/themes/humanity-theme`.
+
+Start, seed, and stop it with:
+
+```bash
+yarn env:e2e:start
+./tests/e2e/support/seed-wordpress.sh
+yarn env:e2e:stop
+```
+
+If the environment must be rebuilt from scratch, use `--force` to avoid the
+interactive prompt:
+
+```bash
+yarn env:e2e:destroy --force
+```
+
+## Running Tests
+
+Run the PR-blocking deterministic suite:
+
+```bash
+yarn test:e2e --grep-invert @cloudflare-smoke
+```
+
+Run all Playwright tests. Without `RUN_CLOUDFLARE_SMOKE=1`, the Cloudflare smoke
+tests are listed but skipped:
+
+```bash
+yarn test:e2e
+```
+
+Run the optional Cloudflare dummy-key smoke tests:
+
+```bash
+RUN_CLOUDFLARE_SMOKE=1 yarn test:e2e tests/e2e/turnstile-cloudflare-dummy.spec.mjs --project=chromium
+```
+
+Open the HTML report after a run:
+
+```bash
+yarn test:e2e:report
+```
+
+## Turnstile Test Strategy
+
+The suite has two layers.
+
+Deterministic tests mock Cloudflare's `api.js` before page navigation. They
+verify the behavior owned by this project:
+
+- the local Turnstile guard is loaded before Cloudflare's script;
+- widgets render with the configured dummy site key;
+- early form submission waits for a Turnstile token;
+- delayed resubmission preserves form data and named submitters;
+- client-side Turnstile failures do not submit the form;
+- missing tokens surface the expected user-facing error.
+
+The Cloudflare smoke tests use the official dummy keys documented by
+Cloudflare. They verify that the real Cloudflare script can create a token and
+that server-side validation accepts and rejects dummy tokens as expected.
+
+Keep deterministic tests as the required PR signal. Keep real Cloudflare smoke
+tests opt-in unless they prove stable enough for every PR.
+
+## CI
+
+The CI frontend job runs from `private/`:
+
+```bash
+yarn install --immutable
+yarn build:prod --env entry=turnstile
+yarn test
+yarn typecheck:turnstile
+yarn playwright install --with-deps chromium
+yarn env:e2e:start
+./tests/e2e/support/seed-wordpress.sh
+yarn test:e2e --grep-invert @cloudflare-smoke
+yarn env:e2e:stop
+```
+
+The stop step must stay guarded with `if: always()` in GitHub Actions so Docker
+containers are stopped even when tests fail.
+
+## Maintenance Notes
+
+- Do not commit real Turnstile keys. Use only Cloudflare dummy keys in this
+  directory.
+- Keep local E2E-only WordPress stubs inside
+  `wordpress/aif-e2e-support/`; do not add them to production code.
+- Keep paths in `.wp-env.e2e.json` relative to the `private/` working
+  directory, because `wp-env` resolves local sources from the command cwd.
+- Prefer route-based Cloudflare mocks for regression tests. Use real Cloudflare
+  only for the small opt-in smoke suite.

--- a/wp-content/plugins/aif-donor-space/README.md
+++ b/wp-content/plugins/aif-donor-space/README.md
@@ -1,0 +1,261 @@
+# AIF Donor Space Plugin
+
+This document describes the `wp-content/plugins/aif-donor-space` subsystem.
+
+## Role
+
+`aif-donor-space` provides the business services used by the authenticated donor
+and member area known as `Mon Espace`.
+
+The plugin is responsible for:
+
+- ensuring the required login, account creation, verification, and `Mon Espace`
+  pages exist;
+- exposing Salesforce helper functions for donor/member data;
+- managing the Salesforce contact identifier stored on WordPress users;
+- sending verification and password reset emails through Mailgun;
+- providing two-factor email verification helpers;
+- creating Salesforce `Case` records for contact requests, tax receipt duplicate
+  requests, and IBAN update requests;
+- exposing a REST endpoint for duplicate tax receipt requests;
+- loading donor-space CSS and small JavaScript helpers;
+- providing shared PHP partials used by theme templates.
+
+The plugin does not render the whole donor space by itself. Most page templates
+and page-specific form handlers still live in `wp-content/themes/humanity-theme`
+and call functions provided by this plugin.
+
+## Directory Layout
+
+Important files and directories:
+
+- `aif-donor-space.php`: plugin header, constants, module loading, page creation,
+  and asset enqueueing.
+- `configuration.php`: requirement checks, parent/theme style loading, admin bar
+  behavior, and partial loading helper.
+- `includes/authorization.php`: access guard for authenticated `Mon Espace`
+  pages.
+- `includes/sales-force/`: Salesforce authentication and data helpers.
+- `includes/domain/2FA/`: email verification code generation, storage, sending,
+  and attempt limiting.
+- `includes/domain/bank/`: IBAN and SEPA mandate helpers.
+- `includes/domain/contact/`: Salesforce contact request creation.
+- `includes/domain/tax-receipt/`: tax receipt grouping helpers, duplicate
+  request creation, and REST controller.
+- `includes/domain/user-authentification.php`: password reset token and Mailgun
+  email helper.
+- `includes/utils.php`: partial include helper.
+- `templates/partials/`: reusable PHP partials consumed by theme pages and
+  patterns.
+- `templates/check-email.php`: legacy page template.
+- `assets/css/` and `assets/js/`: static plugin assets enqueued on the
+  frontend.
+
+## Bootstrap
+
+The plugin defines:
+
+- `AIF_DONOR_SPACE_PATH`;
+- `AIF_DONOR_SPACE_VERSION`;
+- `AIF_DONOR_SPACE_URL`.
+
+It then loads configuration, authorization, Salesforce helpers, domain modules,
+and utilities through `require_once`.
+
+The plugin hooks into WordPress with:
+
+- `init`: periodically ensures critical pages exist;
+- `after_switch_theme`: creates the same critical pages after theme activation;
+- `wp_enqueue_scripts`: loads plugin frontend CSS and JavaScript;
+- `admin_notices`: checks required Salesforce and Mailgun environment variables;
+- `rest_api_init`: registers the tax receipt duplicate request endpoint.
+
+## Created Pages
+
+`aif_donor_space_create_pages()` creates or ensures the following page tree:
+
+- `connectez-vous`;
+- `creer-votre-compte`;
+- `verifier-votre-email`;
+- `mot-de-passe-oublie`;
+- `mon-espace`;
+- `mon-espace/actualites`;
+- `mon-espace/agir-et-se-mobiliser`;
+- `mon-espace/agir-et-se-mobiliser/actualites-militantes`;
+- `mon-espace/agir-et-se-mobiliser/nos-petitions`;
+- `mon-espace/vie-democratique`;
+- `mon-espace/vie-democratique/actualites-democratiques`;
+- `mon-espace/vie-democratique/ressources-vie-democratique`;
+- `mon-espace/boite-a-outils`;
+- `mon-espace/boite-a-outils/ressources-militants`;
+- `mon-espace/boite-a-outils/se-former`;
+- `mon-espace/mes-dons`;
+- `mon-espace/mes-dons/mes-informations-personnelles`;
+- `mon-espace/mes-dons/mes-recus-fiscaux`;
+- `mon-espace/mes-dons/mes-demandes`;
+- `mon-espace/mes-dons/nous-contacter`;
+- `mon-espace/mon-compte`;
+- `mon-espace/mon-compte/se-deconnecter`.
+
+The `init` hook protects this page creation with the
+`aif_critical_pages_check_lock` transient for five minutes.
+
+## Theme Integration
+
+The theme remains the main rendering layer for the donor space.
+
+Important theme integration points:
+
+- `includes/my-space/template.php` detects pages under `mon-espace`, chooses the
+  specific PHP or HTML template, and calls `check_user_page_access()`.
+- `page-connectez-vous.php` uses plugin Salesforce helpers, stores the
+  Salesforce contact ID on successful login, and renders the login form.
+- `page-creer-votre-compte.php` checks Salesforce membership/donor eligibility,
+  creates the WordPress user, generates a 2FA code, and sends it through
+  Mailgun.
+- `page-verifier-votre-email.php` verifies the 2FA code and can send a new one.
+- `page-mes-dons.php`, `page-mes-informations-personnelles.php`,
+  `page-mes-recus-fiscaux.php`, `page-mes-demandes.php`, and
+  `page-modification-coordonnees-bancaire.php` call the plugin Salesforce and
+  domain helpers.
+- `patterns/contact-us.php` creates Salesforce contact requests through the
+  plugin.
+- several theme pages and patterns render shared plugin partials with
+  `aif_include_partial()`.
+
+Because the theme directly calls plugin functions, the donor-space templates
+expect this plugin to be active.
+
+## Salesforce Integration
+
+Salesforce authentication uses the client credentials flow.
+
+Required variables:
+
+- `AIF_SALESFORCE_URL`;
+- `AIF_SALESFORCE_CLIENT_ID`;
+- `AIF_SALESFORCE_SECRET`.
+
+The access token is cached in WordPress options:
+
+- `salesforce_access_token`;
+- `salesforce_token_expiration_time`.
+
+The plugin exposes generic helpers:
+
+- `get_salesforce_data_donor_space()`;
+- `post_salesforce_data_donor_space()`;
+- `patch_salesforce_data_donor_space()`.
+
+It also exposes donor-space specific helpers for:
+
+- member lookup by email;
+- Contact lookup by Salesforce ID;
+- Contact update;
+- tax receipt retrieval;
+- SEPA mandate retrieval;
+- demand retrieval;
+- donor/member access checks.
+
+The Salesforce contact ID is stored as WordPress user meta under `user_SF_ID`.
+
+## Mailgun Integration
+
+Mailgun is used to send:
+
+- 2FA verification emails;
+- password reset emails.
+
+Required variables:
+
+- `AIF_MAILGUN_TOKEN`;
+- `AIF_MAILGUN_URL`;
+- `AIF_MAILGUN_DOMAIN`.
+
+The plugin sends Mailgun template emails with `wp_remote_post()`.
+
+## Authentication And Access
+
+`check_user_page_access()` protects authenticated `Mon Espace` pages. It:
+
+- redirects anonymous users to `connectez-vous` with a `redirect_to` query
+  parameter;
+- loads the current user's Salesforce member data;
+- redirects users without Salesforce data;
+- redirects users without donor/member access.
+
+The theme also applies member-specific restrictions in
+`includes/my-space/template.php`: non-members are redirected to the donor area
+and can only access a reduced list of `Mon Espace` pages.
+
+The 2FA module stores verification state and login attempt state in user meta:
+
+- `2fa_code`;
+- `email-verfied`;
+- `login_attempts`;
+- `login_blocked_until`.
+
+## REST API
+
+The plugin registers:
+
+- namespace: `aif-donor-space/v1`;
+- route: `/duplicate-tax-receipt-request/`;
+- method: `POST`;
+- callback: `handle_duplicate_tax_receipt_request()`;
+- permission callback: `check_nonce()`.
+
+The endpoint requires:
+
+- a valid `X-WP-Nonce` header for `wp_rest`;
+- an authenticated WordPress user;
+- a stored Salesforce contact ID;
+- a `taxReceiptReference` JSON parameter.
+
+On success, it creates a Salesforce `Case` requesting a duplicate tax receipt.
+
+## Frontend Assets
+
+The plugin enqueues these assets on the frontend:
+
+- `assets/css/style.css`;
+- `assets/js/check-password.js`;
+- `assets/js/display-password.js`;
+- `assets/js/dropdown.js`;
+- `assets/js/iban-formatter.js`;
+- `assets/js/create-duplicate-tax-receipt-demand.js`.
+
+The duplicate tax receipt script receives `aifDonorSpace.nonce` and
+`aifDonorSpace.root` through `wp_localize_script()`.
+
+These assets are static files in the plugin. They are not built by the
+`private` Webpack pipeline.
+
+## Environment Checks
+
+On admin pages, `aif_donor_space_check_requirements()` checks the required
+Salesforce and Mailgun variables for administrators. If one is missing, it shows
+an admin notice and calls `deactivate_plugins('aif-donor-space')`.
+
+## Change Conventions
+
+When changing this plugin:
+
+- keep service helpers in the plugin and page rendering in the theme unless the
+  subsystem boundary is intentionally changed;
+- check theme templates when changing any public plugin function;
+- keep Salesforce object field names and record type IDs explicit and reviewed
+  with the business owner;
+- preserve the `redirect_to` login flow used by protected `Mon Espace` pages;
+- update or add REST nonce checks for browser-triggered endpoints;
+- document any new required environment variable in this README and in the
+  global environment documentation.
+
+Recommended checks:
+
+- PHP syntax for changed plugin and theme files;
+- manual login/account creation/2FA flow testing in a local or staging
+  environment configured with Salesforce and Mailgun credentials;
+- REST endpoint testing while logged in and logged out;
+- Turnstile checks when editing login, account creation, or email verification
+  forms in the theme.

--- a/wp-content/themes/humanity-theme/README.md
+++ b/wp-content/themes/humanity-theme/README.md
@@ -1,0 +1,429 @@
+# Humanity Theme
+
+This document describes the project-specific architecture of
+`wp-content/themes/humanity-theme`.
+
+## Role
+
+`humanity-theme` is the main WordPress theme used by the Amnesty International
+France website. It is derived from Amnesty International's upstream Humanity
+theme, but it also contains a large amount of project-specific application code.
+
+The theme is responsible for:
+
+- public and authenticated page rendering;
+- Full Site Editing templates, template parts, and PHP patterns;
+- custom PHP-rendered Gutenberg blocks;
+- custom post types and taxonomies;
+- admin options and editor behavior;
+- REST endpoints used by the frontend and editor;
+- search customization;
+- Salesforce integration for petitions, newsletters, users, and cases;
+- local petition and urgent action persistence;
+- `Mon Espace` routing, templates, access rules, and breadcrumbs;
+- Cloudflare Turnstile integration for sensitive forms;
+- integrations with Jetpack, Yoast SEO, The Events Calendar, WooCommerce, and
+  MultilingualPress when available.
+
+Because of that scope, the theme currently acts as both a presentation layer and
+an application integration layer.
+
+## Directory Layout
+
+Important directories and files:
+
+- `functions.php`: theme bootstrap and top-level module loading.
+- `theme.json`: editor and design settings exposed to WordPress.
+- `templates/`: Full Site Editing block templates.
+- `parts/`: reusable Full Site Editing template parts.
+- `patterns/`: PHP block patterns used by templates and content views.
+- `partials/`: lower-level PHP view partials used by patterns/templates.
+- `includes/`: theme setup, helpers, blocks, post types, taxonomies, REST API,
+  business modules, and third-party plugin integrations.
+- `commands/`: WP-CLI commands loaded only in CLI context.
+- `assets/`: built scripts, styles, images, fonts, and source maps consumed by
+  WordPress.
+- `styles/`: style variations exposed through WordPress.
+- `page-*.php`: classic PHP templates for specific pages, mostly authentication
+  and `Mon Espace` flows.
+- `tribe/` and `tribe-events/`: template overrides for The Events Calendar.
+
+Generated or bulky directories such as `assets/` and `languages/` should not be
+used as primary source-of-truth when changing theme behavior. The frontend
+source of truth is `private/src`.
+
+## Bootstrap
+
+The theme bootstrap is centralized in `functions.php`.
+
+The file loads modules in broad groups:
+
+- root behavior: compatibility, caching, localization, accessibility, permalinks;
+- helpers: archive, media, blocks, taxonomies, metadata, pagination, frontend
+  utilities;
+- admin and network options;
+- theme setup: supports, navigation, body/head hooks, media, scripts/styles,
+  analytics;
+- KSES allowlists;
+- PHP-rendered blocks and core block modifications;
+- block pattern registration;
+- post types and taxonomies;
+- query filters;
+- Salesforce connector;
+- document, petition, and urgent action modules;
+- search;
+- REST API;
+- RSS feed behavior;
+- SEO;
+- users;
+- Jetpack;
+- `Mon Espace`;
+- optional WooCommerce and MultilingualPress integrations.
+
+Most modules register themselves through WordPress hooks during load. This means
+adding a module generally requires two steps:
+
+1. create the implementation under the relevant `includes/*` directory;
+2. add a `require_once` in the corresponding section of `functions.php`.
+
+## Rendering Model
+
+The theme uses a hybrid rendering model:
+
+- Full Site Editing templates in `templates/*.html` define most page, archive,
+  taxonomy, and single layouts.
+- Template parts in `parts/*.html` provide reusable header, footer, and form
+  fragments.
+- PHP block patterns in `patterns/*.php` provide dynamic layout fragments and
+  business-aware rendering.
+- Classic PHP templates handle pages that need direct PHP control, especially
+  login, password, account, and `Mon Espace` pages.
+- `template-html-wrapper.php` bridges selected HTML templates into classic PHP
+  template resolution.
+
+For `Mon Espace`, `includes/my-space/template.php` applies a dedicated template
+selection layer:
+
+- if a specific `page-{slug}.php` exists, it is used;
+- otherwise a specific `templates/page-{slug}.html` can be wrapped;
+- otherwise `templates/page-my-space-default.html` is used as fallback for pages
+  under `/mon-espace`.
+
+This makes the authenticated area partly page-tree driven and partly
+template-driven.
+
+## Blocks And Patterns
+
+PHP-rendered Gutenberg blocks live under `includes/blocks`. Each block usually
+has a `register.php` file and, when dynamic rendering is needed, a `render.php`
+file.
+
+`includes/blocks/register.php` loads and registers the custom block set on
+`init`. Examples include:
+
+- cards and lists: article, chronicle, document, EDH, event, petition, training;
+- layout blocks: section, carousel, slider, hero, call to action;
+- campaign blocks: petition list, tweet action, urgent register form;
+- navigation/content helpers: menu, term list, related posts, read more;
+- homepage-specific blocks.
+
+Core WordPress blocks are adjusted under `includes/core-blocks`. Those files
+modify behavior or styles for selected core blocks such as buttons, images,
+post content, query pagination, and social icons.
+
+Block patterns live in `patterns/`. They are used as higher-level presentation
+fragments for pages, archives, taxonomies, single content, sidebars, forms, and
+`Mon Espace` views.
+
+When adding rendering code:
+
+- use a block when the editor needs a reusable editable unit;
+- use a pattern when composing page or archive structure;
+- use a partial when extracting reusable PHP markup;
+- use a classic PHP template only when WordPress template resolution or
+  request-specific control is required.
+
+## Content Model
+
+The theme registers multiple custom post types. Some use direct registration
+functions; others use `Amnesty\Post_Type`, an abstract base class that supports
+feature toggles and localized permalink settings.
+
+Important post types include:
+
+- `petition`;
+- `document`;
+- `newsletter`;
+- `chronique`;
+- `edh`;
+- `training`;
+- `press-release`;
+- `local-structures`;
+- `actualities-my-space`;
+- `alert-banner`;
+- `country`;
+- `landmark`;
+- `portrait`;
+- `sidebar`;
+- `pop-in`.
+
+Taxonomies use a similar pattern through `Amnesty\Taxonomy`, which supports
+feature toggles, localized slugs, REST metadata, custom templates, and admin
+form adjustments.
+
+Important taxonomies include:
+
+- `category` as the content type taxonomy wrapper;
+- `combat`;
+- `location`;
+- `keyword`;
+- `landmark_category`;
+- `document_type`;
+- `document_democratic_type`;
+- `document_instance_type`;
+- `document_militant_type`.
+
+Several default terms are seeded on `after_switch_theme` from
+`includes/theme-setup/*`, for example categories, countries, combats, keywords,
+and document classification terms.
+
+## Business Tables
+
+The theme creates and uses local business tables:
+
+- `wp_aif_users`: local signer/user identity data;
+- `wp_aif_petitions_signatures`: petition signatures and Salesforce sync state;
+- `wp_aif_urgent_action`: urgent action registrations and Salesforce sync state.
+
+Those tables are created with `dbDelta()` on `after_switch_theme`. The urgent
+action schema also exposes a WP-CLI schema update command through
+`wp update-db-schema`.
+
+The schema is part of the theme today, even though it represents application
+business data rather than presentation data. Any schema change should be handled
+with an explicit version/update path, not only by changing the create-table SQL.
+
+## Internal Business Modules
+
+### Salesforce
+
+Salesforce integration lives under `includes/salesforce`.
+
+The module handles:
+
+- client credentials authentication;
+- token caching in WordPress options;
+- generic GET/POST/PATCH helpers;
+- petition creation and updates;
+- petition signature Bulk API synchronization;
+- user, newsletter, and case calls.
+
+Required environment variables are read with `getenv()`, mainly:
+
+- `AIF_SALESFORCE_URL`;
+- `AIF_SALESFORCE_CLIENT_ID`;
+- `AIF_SALESFORCE_SECRET`;
+- several `AIF_SALESFORCE_CODES_*` values for origin and campaign mapping.
+
+### Petitions
+
+The petition module lives under `includes/petitions`.
+
+It handles:
+
+- local signer storage;
+- local petition signature storage;
+- Salesforce petition creation on `acf/save_post`;
+- petition end-date updates in Salesforce;
+- email existence checks through `humanity/v1/check-email`;
+- WP-CLI synchronization of pending signatures to Salesforce.
+
+### Urgent Actions
+
+The urgent action module lives under `includes/urgent-action`.
+
+It handles:
+
+- local urgent action table creation;
+- duplicate registration checks;
+- unsynchronized action lookup;
+- Salesforce synchronization through WP-CLI;
+- schema update command used during production deployment.
+
+### Documents
+
+The document module includes REST search endpoints for private resource
+documents and a WP-CLI command to report broken document links/files.
+
+Document access and file handling logic is concentrated in
+`includes/post-types/document.php`, which is currently one of the larger theme
+modules.
+
+### Search
+
+Search customization lives under `includes/features/search`.
+
+It provides:
+
+- pretty search URLs;
+- custom search query variables;
+- taxonomy filters;
+- title-only filtering in some contexts;
+- SQL rewriting for richer filtered searches;
+- dedicated search page/result helpers.
+
+### `Mon Espace`
+
+`Mon Espace` behavior lives under `includes/my-space` and the `page-*.php`
+templates.
+
+It handles:
+
+- template resolution for pages under `/mon-espace`;
+- authentication checks;
+- member/non-member access restrictions;
+- redirects for unauthorized pages;
+- Yoast breadcrumb customization for authenticated-area contexts.
+
+## REST API
+
+The theme registers several REST endpoints. Important namespaces include:
+
+- `amnesty/v1`: categories, menus, local structure search, geocode proxy;
+- `humanity/v1`: email checks and document search endpoints;
+- WordPress REST user endpoints extended through a custom users controller.
+
+Some endpoints are public, while others require `is_user_logged_in`,
+WordPress capabilities, or nonce validation. Permission handling should be
+reviewed when adding endpoints, especially for routes that expose business data
+or proxy external services.
+
+## Assets
+
+The theme does not own the frontend source files directly. Built assets are
+stored under `wp-content/themes/humanity-theme/assets`, but source files live in
+`private/src`.
+
+Theme enqueueing happens mainly in
+`includes/theme-setup/scripts-and-styles.php`:
+
+- `bundle.css` and `bundle.js` are loaded on the frontend;
+- `admin.css` and `admin.js` are loaded in wp-admin;
+- `blocks.js` and `blocks.css` are loaded in the block editor;
+- `editor.css` is loaded for editor block assets;
+- `print.css` is loaded for printable post pages;
+- localized data is passed to frontend and editor scripts through
+  `wp_localize_script`.
+
+The global frontend app is exposed as `window.App.default()` and is triggered by
+an inline footer script registered by the theme. The inline script is also added
+to the theme CSP hash filter.
+
+The dedicated Turnstile asset is loaded from `assets/scripts/turnstile.js` when
+`TURNSTILE_SITE_KEY` is configured.
+
+## Third-Party Plugin Integrations
+
+The theme contains integration code for optional or required plugins:
+
+- Jetpack: contact form behavior, sitemap/search redirects, go-back messages.
+- Yoast SEO: breadcrumbs, titles, canonical, Open Graph, primary term handling.
+- The Events Calendar: taxonomy/meta box cleanup, venue API enrichment, template
+  overrides.
+- WooCommerce: loaded conditionally when WooCommerce is active, including cart,
+  checkout, product, order, and template helpers.
+- MultilingualPress: loaded conditionally for multilingual metadata, REST API,
+  scheduled posts, and language selector behavior.
+- CMB2/ACF: admin options, metaboxes, theme settings, and field definitions.
+
+When touching integration code, verify that the plugin is available in the
+target environment and that CI has stubs or plugin files for static analysis.
+
+## Cloudflare Turnstile
+
+Turnstile is integrated directly in the theme, not through the Cloudflare
+WordPress plugin.
+
+The theme:
+
+- renders `.cf-turnstile` containers in specific forms/patterns;
+- loads local `aif-turnstile` before Cloudflare's `api.js`;
+- adds a preconnect hint for `https://challenges.cloudflare.com`;
+- validates submitted tokens server-side through Cloudflare `siteverify`;
+- maps Cloudflare error codes to user-facing French messages.
+
+The corresponding frontend guard is sourced from `private/src/scripts` and built
+into `assets/scripts/turnstile.js`.
+
+## WP-CLI Commands
+
+Theme commands are loaded only when `WP_CLI` is active.
+
+Known commands include:
+
+- `wp duplicate-countries`;
+- `wp update-countries`;
+- `wp sync` for petition signature synchronization;
+- `wp sync` for urgent action synchronization;
+- `wp table-urgent-action`;
+- `wp update-db-schema`;
+- `wp document-broken-list`.
+
+There is command-name overlap around `wp sync` between petition and urgent
+action synchronization. This should be reviewed before adding more WP-CLI
+commands.
+
+## Admin And Editor Behavior
+
+Admin behavior is spread across `includes/admin`, CMB2/ACF field definitions,
+theme option pages, and editor asset localization.
+
+The theme provides:
+
+- theme option pages for header, footer, social links, analytics, localization,
+  news, and pop-ins;
+- feature toggles for post types and taxonomies;
+- permalink settings for localized slugs;
+- block validation/display controls;
+- user options;
+- list table filters;
+- local structure search tools;
+- accessibility and general settings helpers.
+
+Editor-facing settings are passed through `blocks.js` localization, including
+available post types, taxonomy metadata, default sidebar settings, feature flags,
+user roles, WordPress version, and optional WooCommerce data.
+
+## Conventions For Changes
+
+When changing theme behavior:
+
+- prefer adding code to the relevant `includes/*` module instead of expanding
+  `functions.php` inline;
+- update `functions.php` only to wire a new module into the bootstrap;
+- put frontend source changes in `private/src`, then rebuild theme assets;
+- keep generated `assets/*` changes tied to their source changes;
+- use existing post type and taxonomy base classes when adding configurable
+  content structures;
+- use existing helper functions before introducing new global helpers;
+- treat business-table changes as migrations and update the related WP-CLI
+  schema path when needed;
+- check plugin availability before depending on third-party plugin symbols;
+- keep public REST endpoints explicit about permissions and sanitization;
+- avoid adding more unrelated business logic to the theme when a dedicated
+  plugin boundary would be cleaner.
+
+## Checks
+
+Relevant checks for theme changes include:
+
+- `composer run cs`;
+- `composer run analyse -- --no-progress`;
+- `composer lint`;
+- `yarn lint:scripts` from `private`;
+- `yarn lint:styles` from `private`;
+- `yarn build:prod` from `private`;
+- targeted tests such as `yarn test` when frontend behavior is touched.
+
+The current CI covers PHP checks and GitHub Actions linting. Frontend checks are
+available locally but are not yet part of the main CI workflow.


### PR DESCRIPTION
## Why
- Provide a first documentation layer for the Turnstile E2E work before the broader subsystem documentation.
- Make local setup, frontend assets, donor-space boundaries, and E2E execution easier to understand while reviewing the test PR stack.

## What changed
- Add architecture and frontend documentation entry points.
- Document the E2E Playwright setup and execution model.
- Expand theme and donor-space README coverage relevant to the Turnstile E2E stack.
- Link the new documentation from the root README.

## Validation
- Rebases cleanly on top of test/turnstile-e2e-coverage.
- Ran git diff --check for this documentation diff.