### PR TITLE
fix: empêcher la réapparition des pétitions skippées dans le tunnel CLH

### DIFF
--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -565,12 +565,6 @@ function amnesty_get_clh_tunnel_context(?WP_Post $post = null): array
     }
 
     $signed_count = count(array_filter($selected_posts, fn ($petition) => $petition['already_signed'] === true));
-    $available_petitions = array_filter(
-        $selected_posts,
-        static fn ($petition) =>
-        $petition['already_signed'] === false &&
-        $petition['active'] === true
-    );
     $not_signed = array_filter(
         $selected_posts,
         static fn ($petition) =>
@@ -578,10 +572,6 @@ function amnesty_get_clh_tunnel_context(?WP_Post $post = null): array
         $petition['already_skipped'] === false &&
         $petition['active'] === true
     );
-
-    if (empty($not_signed)) {
-        $not_signed = $available_petitions;
-    }
 
     $next_petition = null;
 

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -71,11 +71,6 @@ foreach ($list_petitions_clh as $petition) {
 $signed_count = count(array_filter($selected_posts, fn($p) => $p['already_signed'] === true));
 $total_steps = min(10, count($list_petitions_clh));
 
-$available_petitions = \array_filter(
-    $selected_posts,
-    static fn($petition) => $petition['already_signed'] === false &&
-        $petition['active'] === true
-);
 $not_signed = \array_filter(
     $selected_posts,
     static fn($petition) => $petition['already_signed'] === false &&
@@ -83,16 +78,7 @@ $not_signed = \array_filter(
         $petition['active'] === true
 );
 
-if (empty($not_signed)) {
-    $not_signed = $available_petitions;
-}
-
 $show_final_screen = $signed_count >= 10 || empty($not_signed);
-
-if (!$show_final_screen && empty($not_signed)) {
-    wp_redirect(amnesty_get_clh_tunnel_end_url());
-    exit();
-}
 
 if ($show_final_screen) {
     $fallback_share_petition = $selected_posts[0] ?? null;


### PR DESCRIPTION
Supprime le fallback qui réinjectait toutes les pétitions skippées dès que la liste des pétitions non signées/non skippées devenait vide, annulant ainsi l'effet du cookie clh_skipped_petitions. L'utilisateur est désormais redirigé vers l'écran de fin une fois toutes les pétitions restantes skippées.