### PR TITLE
fix: maint 178 update support email

### DIFF
--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -381,6 +381,7 @@ require_once realpath(__DIR__ . '/includes/seo/schema-breadcrumbs.php');
 require_once realpath(__DIR__ . '/includes/users/class-users-controller.php');
 require_once realpath(__DIR__ . '/includes/users/contact-methods.php');
 require_once realpath(__DIR__ . '/includes/users/meta.php');
+require_once realpath(__DIR__ . '/includes/users/emails.php');
 // endregion users
 
 /**

--- a/wp-content/themes/humanity-theme/includes/users/emails.php
+++ b/wp-content/themes/humanity-theme/includes/users/emails.php
@@ -11,7 +11,7 @@
  */
 add_filter(
     'password_change_email',
-    static function ( array $email_args ): array {
+    static function (array $email_args): array {
         $email_args['message'] = str_replace(
             '###ADMIN_EMAIL###',
             'smd@amnesty.fr',

--- a/wp-content/themes/humanity-theme/includes/users/emails.php
+++ b/wp-content/themes/humanity-theme/includes/users/emails.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Override the support contact address in the WordPress "password changed"
+ * notification email.
+ *
+ * WordPress core (wp-includes/user.php) replaces ###ADMIN_EMAIL### with
+ * get_option('admin_email') *after* the password_change_email filter runs.
+ * We pre-replace the placeholder here so the core str_replace becomes a no-op
+ * and our address is always used, regardless of the admin_email option value.
+ */
+add_filter(
+    'password_change_email',
+    static function ( array $email_args ): array {
+        $email_args['message'] = str_replace(
+            '###ADMIN_EMAIL###',
+            'smd@amnesty.fr',
+            $email_args['message']
+        );
+
+        return $email_args;
+    }
+);

--- a/wp-content/themes/humanity-theme/includes/users/emails.php
+++ b/wp-content/themes/humanity-theme/includes/users/emails.php
@@ -14,7 +14,7 @@ add_filter(
     static function (array $email_args): array {
         $email_args['message'] = str_replace(
             '###ADMIN_EMAIL###',
-            'smd@amnesty.fr',
+            getenv('AIF_SUPPORT_EMAIL') ?: 'smd@amnesty.fr',
             $email_args['message']
         );
 


### PR DESCRIPTION
fix(emails): force l'adresse support dans l'email de changement de mot de passe

L'option admin_email (utilisée via ###ADMIN_EMAIL###) pointait vers le
prestataire au lieu du support Amnesty, et sa correction via wp-admin était
bloquée par la validation email de WordPress.

Ajout d'un filtre password_change_email qui force smd@amnesty.fr dans le
message, indépendamment de admin_email.