### PR TITLE
feat(theme): add news archive page grouped by year and month

### DIFF
--- a/private/src/scripts/App.js
+++ b/private/src/scripts/App.js
@@ -27,6 +27,7 @@ import initCarousels from './modules/carousel';
 import tableOfContents from './modules/table-of-contents';
 import readMoreBlock from './modules/read-more';
 import initAZFilter from './modules/az-filter';
+import initActualitesArchive from './modules/actualites-archive';
 import { getUserLocationFromButton, getUserLocationFromForm } from './modules/localisation';
 import enhanceJetpackFormPlaceholders from './modules/jetpack-form-fix';
 import { calculator, hoverDonationMenu } from './modules/donation-calculator';
@@ -73,6 +74,7 @@ const App = () => {
   tableOfContents();
   readMoreBlock();
   initAZFilter();
+  initActualitesArchive();
   getUserLocationFromButton();
   getUserLocationFromForm();
   enhanceJetpackFormPlaceholders();

--- a/private/src/scripts/modules/actualites-archive.js
+++ b/private/src/scripts/modules/actualites-archive.js
@@ -1,0 +1,36 @@
+const actualitesArchive = () => {
+  const root = document.querySelector('.actualites-archive');
+
+  if (!root) return;
+
+  const tabs = root.querySelectorAll('.az-letter');
+  const blocks = root.querySelectorAll('.actualites-year-block');
+  const display = root.querySelector('.az-letter-display');
+
+  if (!tabs.length || !blocks.length) return;
+
+  const showYear = (year) => {
+    if (display) display.textContent = year;
+
+    blocks.forEach((el) => {
+      const element = el;
+      element.style.display = el.dataset.year === year ? 'block' : 'none';
+    });
+
+    tabs.forEach((tab) => {
+      const isActive = tab.dataset.year === year;
+      tab.classList.toggle('active', isActive);
+      tab.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  };
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => showYear(tab.dataset.year));
+  });
+
+  const initial = root.querySelector('.az-letter.active') || tabs[0];
+
+  showYear(initial.dataset.year);
+};
+
+export default actualitesArchive;

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -157,6 +157,7 @@
 @import 'pages/search';
 @import 'pages/news';
 @import 'pages/archive';
+@import 'pages/actualites-archive';
 @import 'pages/petitions';
 @import 'pages/single';
 @import 'pages/author';

--- a/private/src/styles/pages/_actualites-archive.scss
+++ b/private/src/styles/pages/_actualites-archive.scss
@@ -1,0 +1,83 @@
+// Reuses the /pays `.az-filter` chrome (index + big display) declared in
+// `pages/_archive.scss`; only the year/month specifics are overridden here.
+.actualites-archive {
+  .az-index {
+    justify-content: center;
+  }
+
+  // `.az-letter` is now a <button> on this page: reset the native chrome
+  // while keeping the shared `.az-letter` look from `pages/_archive.scss`.
+  .az-letter {
+    width: auto;
+    min-width: 75px;
+    padding: 0 16px;
+    border: 0;
+    font: inherit;
+    font-weight: bold;
+  }
+
+  // Keep the big year number visible while scrolling its month list.
+  .az-letter-display {
+    position: sticky;
+    top: 16px;
+    align-self: flex-start;
+  }
+
+  // On mobile, stack the year above its content (single column).
+  @media (max-width: $container-md) {
+    .az-display {
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .az-letter-display {
+      position: static;
+    }
+  }
+
+  .actualites-years {
+    width: 100%;
+  }
+
+  // Hidden by default; the active year is revealed by JS. The first block
+  // stays visible as a no-JS fallback (it is also the most recent year).
+  .actualites-year-block {
+    display: none;
+
+    &:first-child {
+      display: block;
+    }
+  }
+
+  .actualites-archive-month {
+    margin-bottom: 24px;
+  }
+
+  .actualites-archive-month-title {
+    width: fit-content;
+    margin-bottom: 0.9rem;
+    padding: 1px 7px;
+    color: var(--wp--preset--color--primary);
+    background-color: var(--wp--preset--color--black);
+    font-size: 1.8rem;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
+
+  .actualites-archive-list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4px 16px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+
+    @media (max-width: $container-sm) {
+      grid-template-columns: 1fr;
+    }
+
+    a {
+      text-decoration: none;
+    }
+  }
+}

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -104,6 +104,7 @@ require_once realpath(__DIR__ . '/includes/helpers/archive-chronicle-helpers.php
 require_once realpath(__DIR__ . '/includes/helpers/list-alignment.php');
 require_once realpath(__DIR__ . '/includes/helpers/reading-time.php');
 require_once realpath(__DIR__ . '/includes/helpers/page-the-chronicle-promo-helpers.php');
+require_once realpath(__DIR__ . '/includes/helpers/actualites-archive-helper.php');
 // endregion helpers
 
 /**

--- a/wp-content/themes/humanity-theme/includes/helpers/actualites-archive-helper.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/actualites-archive-helper.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Builds a chronological archive of "actualités" posts grouped by year then month.
+ *
+ * Returns a nested structure ordered most-recent first:
+ * [
+ *   2026 => [
+ *     6 => [ 'label' => 'Juin', 'items' => [ ['title' => ..., 'url' => ...], ... ] ],
+ *     ...
+ *   ],
+ *   ...
+ * ]
+ *
+ * Only titles, permalinks and dates are read, so the full archive stays light.
+ * The result is cached statically to run the query only once per request.
+ *
+ * @return array<int, array<int, array{label: string, items: array<int, array{title: string, url: string}>}>>
+ */
+function aif_get_actualites_archive_grouped(): array
+{
+    static $grouped = null;
+
+    if ($grouped !== null) {
+        return $grouped;
+    }
+
+    $grouped = [];
+
+    $query = new WP_Query([
+        'post_type'              => 'post',
+        'post_status'            => 'publish',
+        'category_name'          => '',
+        'posts_per_page'         => -1,
+        'orderby'                => 'date',
+        'order'                  => 'DESC',
+        'no_found_rows'          => true,
+        'update_post_meta_cache' => false,
+        'update_post_term_cache' => false,
+    ]);
+
+    foreach ($query->posts as $post) {
+        $year  = (int) get_the_date('Y', $post);
+        $month = (int) get_the_date('n', $post);
+
+        if (!isset($grouped[$year][$month])) {
+            $grouped[$year][$month] = [
+                'label' => ucfirst((string) wp_date('F', (int) get_post_timestamp($post))),
+                'items' => [],
+            ];
+        }
+
+        $grouped[$year][$month]['items'][] = [
+            'title' => get_the_title($post),
+            'url'   => (string) get_permalink($post),
+        ];
+    }
+
+    wp_reset_postdata();
+
+    return $grouped;
+}

--- a/wp-content/themes/humanity-theme/patterns/actualites-archive.php
+++ b/wp-content/themes/humanity-theme/patterns/actualites-archive.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Title: Actualités archive
+ * Description: Chronological list of all actualités, grouped by year then month, with a /pays-style year filter.
+ * Slug: amnesty/actualites-archive
+ * Inserter: no
+ */
+
+$grouped = aif_get_actualites_archive_grouped();
+$years   = array_keys($grouped);
+?>
+
+<div class="az-filter actualites-archive">
+    <?php if (empty($grouped)) : ?>
+        <p>Aucune actualité n’a été trouvée.</p>
+    <?php else : ?>
+        <h2 class="title">Toutes les actualités</h2>
+
+        <div class="az-index" role="group" aria-label="Filtrer les actualités par année">
+            <?php foreach ($years as $index => $year) : ?>
+                <button type="button" class="az-letter<?php echo $index === 0 ? ' active' : ''; ?>" data-year="<?php echo esc_attr((string) $year); ?>" aria-pressed="<?php echo $index === 0 ? 'true' : 'false'; ?>">
+                    <?php echo esc_html((string) $year); ?>
+                </button>
+            <?php endforeach; ?>
+        </div>
+
+        <div class="az-display">
+            <div class="az-letter-display" aria-hidden="true"><?php echo esc_html((string) $years[0]); ?></div>
+
+            <div class="actualites-years">
+                <?php foreach ($grouped as $year => $months) : ?>
+                    <div class="actualites-year-block" data-year="<?php echo esc_attr((string) $year); ?>" role="region" aria-label="<?php echo esc_attr(sprintf('Actualités de %s', $year)); ?>">
+                        <?php foreach ($months as $month) : ?>
+                            <div class="actualites-archive-month">
+                                <h3 class="actualites-archive-month-title"><?php echo esc_html($month['label']); ?></h3>
+                                <ul class="actualites-archive-list">
+                                    <?php foreach ($month['items'] as $item) : ?>
+                                        <li>
+                                            <a href="<?php echo esc_url($item['url']); ?>"><?php echo esc_html($item['title']); ?></a>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    <?php endif; ?>
+</div>

--- a/wp-content/themes/humanity-theme/templates/page-actualites-archive.html
+++ b/wp-content/themes/humanity-theme/templates/page-actualites-archive.html
@@ -1,0 +1,28 @@
+<!-- wp:group {"tagName":"main"} -->
+<main class="wp-block-group">
+    <!-- wp:group {"tagName":"div","className":"section"} -->
+    <div class="wp-block-group section">
+        <!-- wp:group {"tagName":"div","className":"container has-gutter"} -->
+        <div class="wp-block-group container has-gutter">
+            <!-- wp:group {"tagName":"div"} -->
+            <div class="wp-block-group">
+                <!-- wp:pattern {"slug":"amnesty/archive-hero"} /-->
+            </div>
+            <!-- /wp:group -->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+    <!-- wp:group {"tagName":"div","className":"container has-gutter"} -->
+    <div class="wp-block-group container has-gutter">
+        <!-- wp:group {"tagName":"section"} -->
+        <section class="wp-block-group">
+            <!-- wp:pattern {"slug":"amnesty/actualites-archive"} /-->
+        </section>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"humanity-theme","area":"footer","className":"amnesty-footer-template-part"} /-->

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -411,5 +411,12 @@
       "title": "Footer",
       "area": "footer"
     }
+  ],
+  "customTemplates": [
+    {
+      "name": "page-actualites-archive",
+      "title": "Archive des actualités",
+      "postTypes": ["page"]
+    }
   ]
 }


### PR DESCRIPTION
Add an "actualités" archive that lists all posts in the `actualites` category, grouped by year then month, reusing the /pays-style A-Z filter (year index + sticky big-year display, single column on mobile, two columns for the month lists).

- helper aif_get_actualites_archive_grouped() (light title/url/date query)
- pattern amnesty/actualites-archive + FSE template page-actualites-archive registered as a customTemplate
- dedicated JS module to filter blocks by year (leaves /pays az-filter intact)
- accessible markup: <button> tabs with aria-pressed, labelled regions, decorative big-year hidden from AT; h1>h2>h3 hierarchy preserved

Desktop:

<img width="2538" height="1098" alt="image" src="https://github.com/user-attachments/assets/9cdcf097-c957-4ed7-85c0-e1122bc4ae8c" />


Mobile: 

<img width="607" height="893" alt="image" src="https://github.com/user-attachments/assets/bf1dfa0a-5b39-4600-94ea-2e3583202f7d" />


Pour tester, créer une nouvelle page dans le back office avec comme slug archive-des-actualites