### PR TITLE
fix: fond jaune pour Article La chronique

### DIFF
--- a/private/src/scripts/editor/blocks/articles-homepage/EditComponent.jsx
+++ b/private/src/scripts/editor/blocks/articles-homepage/EditComponent.jsx
@@ -106,6 +106,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
       const categoryMap = {
         landmark: 'landmark',
         'actualities-my-space': 'actualities-my-space',
+        chronique: 'chroniques',
       };
 
       const category = categoryMap[post.type] || primaryCategory?.slug || '';

--- a/wp-content/themes/humanity-theme/includes/blocks/articles-homepage/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/articles-homepage/render.php
@@ -146,6 +146,9 @@ if (!function_exists('render_articles_homepage_block')) {
             } elseif ($current_post_type === 'landmark') {
                 $entity_slug = 'landmark';
                 $entity_label = 'Repère';
+            } elseif ($current_post_type === 'chronique') {
+                $entity_slug = 'chroniques';
+                $entity_label = 'Article La Chronique';
             }
 
             if (empty($entity_slug) && $category_slug_from_attributes) {


### PR DESCRIPTION
https://linear.app/les-tilleuls/issue/MAINT-243

# Description
Cette PR corrige l’affichage du libellé des contenus de type chronique dans le bloc Articles Homepage.
Les articles “La Chronique” sont maintenant associés au slug chroniques, ce qui permet au rendu front d’appliquer la classe attendue bg-yellow sur le chip-category, comme pour les autres contenus qui doivent apparaître en noir sur fond jaune.

# Changements
Ajout du mapping chronique -> chroniques côté éditeur pour le bloc Articles Homepage.
Gestion explicite du post type chronique côté rendu PHP.
Affichage du label Article La Chronique.
Application du style existant chip-category bg-yellow via le slug chroniques.

#Tests
Vérification locale via WP-CLI du rendu du bloc Articles Homepage avec des contenus chronique.
Résultat attendu confirmé : le HTML généré contient bien chip-category bg-yellow small.

<img width="771" height="391" alt="Capture d’écran 2026-06-19 à 15 57 36" src="https://github.com/user-attachments/assets/0d2b0a96-c5fc-43c4-b68d-d7ff614a508d" />
