### PR TITLE
feat: modification de wording du cartouche pour action-soutien

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -27,13 +27,14 @@ $post_id = get_the_ID();
 $civility = $civility ?? 'M.';
 
 $turnstile_error_message = $GLOBALS['petition_turnstile_error_message'] ?? '';
+$sticky_card_title = $type === 'action-soutien' ? 'SOUTIEN' : 'SIGNEZ LA PÉTITION';
 
 ?>
 
 <aside class="petition-aside" id="petition">
   <div class="sticky-card">
     <div class="sticky-card-content">
-      <div class="sticky-card-title">SIGNEZ LA PÉTITION</div>
+      <div class="sticky-card-title"><?php echo esc_html($sticky_card_title); ?></div>
       <p class="recipient"><?php echo esc_html($recipient ?? ''); ?><?php echo esc_html($form_contenu ?? ''); ?></p>
         <?php if ($type === 'petition') : ?>
       <div class="punchline-wrapper">


### PR DESCRIPTION
https://linear.app/les-tilleuls/issue/MAINT-244

## Contexte

Les actions de soutien utilisent le post type `petition`, mais doivent être distinguées des pétitions classiques dans le cartouche sticky du formulaire.

Actuellement, le titre du cartouche `.sticky-card-title` affichait toujours `SIGNEZ LA PÉTITION`, y compris pour les actions de soutien.

## Modification

- Ajout d’un libellé conditionnel dans `aside-petition-sticky.php`
- Affichage de `SOUTIEN` lorsque le champ ACF `type` vaut `action-soutien`
- Conservation de `SIGNEZ LA PÉTITION` pour les pétitions classiques

## Vérification

- `php -l wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php`
- Vérification du diff : changement limité au titre du cartouche sticky