### PR TITLE
feat: modification wording breadcrumb soutien

### DIFF
--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -58,6 +58,33 @@ function amnesty_register_petition_type_meta()
 }
 add_action('init', 'amnesty_register_petition_type_meta');
 
+function amnesty_custom_support_petition_breadcrumbs($links)
+{
+    if (! is_singular('petition')) {
+        return $links;
+    }
+
+    $type_field = function_exists('get_field') ? get_field('type') : null;
+    $type = is_array($type_field) ? ($type_field['value'] ?? '') : (string) $type_field;
+
+    if ($type === '') {
+        $type = get_post_meta(get_the_ID(), 'type', true);
+    }
+
+    if ($type !== 'action-soutien') {
+        return $links;
+    }
+
+    foreach ($links as $index => $link) {
+        if (($link['text'] ?? '') === 'Pétitions') {
+            $links[$index]['text'] = 'Soutien';
+        }
+    }
+
+    return $links;
+}
+add_filter('wpseo_breadcrumb_links', 'amnesty_custom_support_petition_breadcrumbs');
+
 function amnesty_get_petition_signature_count($post_id)
 {
     $count = get_post_meta($post_id, '_amnesty_signature_count', true);

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -58,32 +58,76 @@ function amnesty_register_petition_type_meta()
 }
 add_action('init', 'amnesty_register_petition_type_meta');
 
+function amnesty_get_petition_type($post_id = null): string
+{
+    $post_id = $post_id ?: get_the_ID();
+    $type_field = function_exists('get_field') ? get_field('type', $post_id) : null;
+    $type = is_array($type_field) ? ($type_field['value'] ?? '') : (string) $type_field;
+
+    if ($type === '') {
+        $type = get_post_meta($post_id, 'type', true);
+    }
+
+    return (string) $type;
+}
+
+function amnesty_get_support_petitions_archive_link(): string
+{
+    $archive_link = get_post_type_archive_link('petition') ?: home_url('/petitions/');
+
+    return add_query_arg('qtype_petition', 'action-soutien', $archive_link);
+}
+
+function amnesty_is_petition_archive_breadcrumb_link(array $link): bool
+{
+    if (($link['ptarchive'] ?? '') === 'petition') {
+        return true;
+    }
+
+    if (empty($link['url'])) {
+        return false;
+    }
+
+    $archive_link = get_post_type_archive_link('petition');
+
+    if (! $archive_link) {
+        return false;
+    }
+
+    $link_path = wp_parse_url($link['url'], PHP_URL_PATH);
+    $archive_path = wp_parse_url($archive_link, PHP_URL_PATH);
+
+    return $link_path && $archive_path && untrailingslashit($link_path) === untrailingslashit($archive_path);
+}
+
 function amnesty_custom_support_petition_breadcrumbs($links)
 {
     if (! is_singular('petition')) {
         return $links;
     }
 
-    $type_field = function_exists('get_field') ? get_field('type') : null;
-    $type = is_array($type_field) ? ($type_field['value'] ?? '') : (string) $type_field;
-
-    if ($type === '') {
-        $type = get_post_meta(get_the_ID(), 'type', true);
-    }
-
-    if ($type !== 'action-soutien') {
+    if (get_query_var('is_my_space_petition') || amnesty_get_petition_type() !== 'action-soutien') {
         return $links;
     }
 
     foreach ($links as $index => $link) {
-        if (($link['text'] ?? '') === 'Pétitions') {
+        if (amnesty_is_petition_archive_breadcrumb_link($link)) {
             $links[$index]['text'] = 'Soutien';
+            $links[$index]['url'] = amnesty_get_support_petitions_archive_link();
         }
     }
 
     return $links;
 }
-add_filter('wpseo_breadcrumb_links', 'amnesty_custom_support_petition_breadcrumbs');
+add_filter('wpseo_breadcrumb_links', 'amnesty_custom_support_petition_breadcrumbs', 20);
+
+function amnesty_petition_add_query_vars($vars)
+{
+    $vars[] = 'qtype_petition';
+
+    return $vars;
+}
+add_filter('query_vars', 'amnesty_petition_add_query_vars');
 
 function amnesty_get_petition_signature_count($post_id)
 {
@@ -206,6 +250,7 @@ function filter_petition_archive(WP_Query $query)
     }
 
     $meta_query_args = [
+        'relation' => 'AND',
         [
             'key' => 'date_de_fin',
             'value' => date('Y-m-d'),
@@ -213,6 +258,17 @@ function filter_petition_archive(WP_Query $query)
             'type' => 'DATE',
         ],
     ];
+
+    $petition_type = sanitize_key((string) get_query_var('qtype_petition'));
+
+    if (in_array($petition_type, [ 'petition', 'action-soutien' ], true)) {
+        $meta_query_args[] = [
+            'key' => 'type',
+            'value' => $petition_type,
+            'compare' => '=',
+        ];
+    }
+
     $query->set('meta_query', $meta_query_args);
 
 

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -177,7 +177,7 @@ function amnesty_handle_petition_signature(): void
         $petition_id = absint($_POST['petition_id']);
         $user_email = sanitize_email($_POST['user_email']);
 
-        $type = get_field('type', $petition_id)['value'];
+        $type = amnesty_get_petition_type($petition_id) ?: 'petition';
         $current_date = date('Y-m-d');
         $end_date = get_field('date_de_fin', $petition_id);
 
@@ -302,7 +302,7 @@ add_action('restrict_manage_posts', function ($post_type) {
 	<select name="type_petition">
 		<option value="">Toutes les pétitions</option>
 		<option value="petition" <?php selected($selected, 'petition'); ?>>Pétition</option>
-		<option value="action-soutien" <?php selected($selected, 'action-soutie'); ?>>Action de soutien</option>
+		<option value="action-soutien" <?php selected($selected, 'action-soutien'); ?>>Action de soutien</option>
 	</select>
 	<?php
 });


### PR DESCRIPTION
## Contexte

Les actions de soutien utilisent le post type `petition`, ce qui entraînait l’affichage du libellé générique `Pétitions` dans le fil d’Ariane Yoast.

Pour ces contenus, le breadcrumb doit afficher `Soutien` afin de mieux refléter leur type réel.

Deux bugs préexistants ont aussi été corrigés dans `petitions.php` :
- une erreur fatale possible lors de la soumission d’une signature si le champ ACF `type` est indisponible ou retourne `false`
- une typo dans le filtre admin qui empêchait l’option `Action de soutien` d’apparaître comme sélectionnée

## Modification

- Ajout d’un filtre `wpseo_breadcrumb_links` pour les contenus `petition`
- Détection du type `action-soutien` via le helper existant `amnesty_get_petition_type()`
- Remplacement du libellé `Pétitions` par `Soutien` dans le breadcrumb Yoast
- Conservation du breadcrumb actuel pour les pétitions classiques
- Sécurisation de la lecture du type de pétition lors de la soumission d’une signature
- Correction de la valeur utilisée par `selected()` dans le filtre admin `Type de pétition`

## Vérification

- `php -l wp-content/themes/humanity-theme/includes/post-types/petitions.php`
- `composer validate --no-check-publish`
- Vérification du diff : changements limités au breadcrumb des actions de soutien et aux deux corrections ciblées dans `petitions.php`