### PR TITLE
chore: purge Cloudflare cache via SSH after deploy (MAINT-182)

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -33,3 +33,5 @@ jobs:
         run: ssh prod '$HOME/deploy.sh'
       - name: Update schema
         run: ssh prod 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT" && wp update-db-schema'
+      - name: Purge Cache Cloudflare
+        run: ssh prod 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT" && wp cloudflare cache purge'

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -33,3 +33,5 @@ jobs:
         run: ssh staging '$HOME/deploy.sh ${{ github.ref_name }}'
       - name: Update schema
         run: ssh staging 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT" && wp update-db-schema'
+      - name: Purge Cache Cloudflare
+        run: ssh staging 'source $HOME/initenv.sh && cd "$DOCUMENT_ROOT" && wp cloudflare cache purge'


### PR DESCRIPTION
Run `wp cloudflare cache purge` over SSH on the target server using the same initenv/DOCUMENT_ROOT pattern as the schema step, instead of on the GitHub runner where wp-cli and the WordPress install are absent.