### PR TITLE
fix: force l'affichage du Turnstile en interaction-only (MAINT-241)

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-petition-sticky.php
@@ -44,7 +44,7 @@ $turnstile_error_message = $GLOBALS['petition_turnstile_error_message'] ?? '';
 		<?php if (isset($end_date) && (strtotime($end_date) >= strtotime($current_date))) : ?>
 
       <form class="signature-petition-form" method="post" action="">
-          <div class="cf-turnstile" data-callback="aifTurnstileSuccess" data-error-callback="aifTurnstileFailure" data-expired-callback="aifTurnstileFailure" data-timeout-callback="aifTurnstileFailure" data-unsupported-callback="aifTurnstileFailure" data-sitekey="<?php echo esc_attr(aif_turnstile_site_key()); ?>"></div>
+          <div class="cf-turnstile" data-callback="aifTurnstileSuccess" data-error-callback="aifTurnstileFailure" data-appearance="interaction-only" data-expired-callback="aifTurnstileFailure" data-timeout-callback="aifTurnstileFailure" data-unsupported-callback="aifTurnstileFailure" data-sitekey="<?php echo esc_attr(aif_turnstile_site_key()); ?>"></div>
           <?php if ($turnstile_error_message) : ?>
               <?php aif_include_partial('alert', ['state' => 'error', 'title' => 'Une erreur est survenue', 'content' => $turnstile_error_message]); ?>
           <?php endif; ?>


### PR DESCRIPTION
Comme pour le footer, ajout de data-appareance au turnstile du HTML. 

L'autre partie du ticket, concernant le tunnel de pétitions, sera effectuée directement sur la branche concernée (sprint/tunnel-clh)