### PR TITLE
feat(pays): convertit /pays/ d'archive CPT en Page WP unique

### DIFF
--- a/private/src/styles/pages/_archive.scss
+++ b/private/src/styles/pages/_archive.scss
@@ -197,6 +197,10 @@
     flex-wrap: wrap;
     gap: 2px;
 
+    @media (max-width: $container-lg) {
+      justify-content: center;
+    }
+
     .az-letter {
       width: 75px;
       height: 75px;

--- a/private/src/styles/pages/page/type/_standard.scss
+++ b/private/src/styles/pages/page/type/_standard.scss
@@ -204,3 +204,16 @@
     max-width: $container-md;
   }
 }
+
+.page-standard.page-pays {
+  .page-hero-block.no-featured-image .page-hero-title-wrapper .container {
+    justify-content: flex-start;
+    padding-left: 24px;
+    padding-right: 24px;
+
+    @media (min-width: $container-hg) {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+}

--- a/wp-content/themes/humanity-theme/includes/post-types/countries.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/countries.php
@@ -21,7 +21,7 @@ function amnesty_register_countries_cpt()
                 'not_found_in_trash' => 'Aucun Pays dans la corbeille',
             ],
             'public'       => true,
-            'has_archive'  => true,
+            'has_archive'  => false,
             'rewrite'      => [ 'slug' => 'pays' ],
             'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields' ],
             'menu_icon'    => 'dashicons-flag',

--- a/wp-content/themes/humanity-theme/patterns/archive-loop.php
+++ b/wp-content/themes/humanity-theme/patterns/archive-loop.php
@@ -44,32 +44,26 @@ if (is_post_type_archive('landmark')) {
 <div class="wp-block-query">
     <!-- wp:group {"tagName":"div","className":""} -->
     <div class="wp-block-group news-section section section--small section--tinted has-gutter">
-        <?php if (get_post_type() === 'fiche_pays') : ?>
-            <!-- wp:pattern {"slug":"amnesty/countries-list"} /-->
-        <?php else : ?>
-            <!-- wp:group {"tagName":"div","className":"postlist"} -->
-            <div class="wp-block-group postlist">
-                <!-- wp:post-template {"layout":{"type":"grid","columnCount":3},"className":"post-grid"} -->
-                    <!-- wp:amnesty-core/article-card {"direction":"portrait"} /-->
-                <!-- /wp:post-template -->
+        <!-- wp:group {"tagName":"div","className":"postlist"} -->
+        <div class="wp-block-group postlist">
+            <!-- wp:post-template {"layout":{"type":"grid","columnCount":3},"className":"post-grid"} -->
+                <!-- wp:amnesty-core/article-card {"direction":"portrait"} /-->
+            <!-- /wp:post-template -->
 
-                <!-- wp:query-no-results -->
-                <div class="wp-block-query-no-results">
-                    <p>Nous n’avons pas trouvé d’articles correspondant à vos critères de recherche.</p>
-                </div>
-                <!-- /wp:query-no-results -->
+            <!-- wp:query-no-results -->
+            <div class="wp-block-query-no-results">
+                <p>Nous n’avons pas trouvé d’articles correspondant à vos critères de recherche.</p>
             </div>
-            <!-- /wp:group -->
-        <?php endif; ?>
+            <!-- /wp:query-no-results -->
+        </div>
+        <!-- /wp:group -->
     </div>
     <!-- /wp:group -->
 
-    <?php if (get_post_type() !== 'fiche_pays') : ?>
-        <!-- wp:query-pagination {"align":"center","className":"section section--small","paginationArrow":"none","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-            <!-- wp:query-pagination-previous {"label":"<?php echo esc_html(__('Previous', 'amnesty')); ?>"} /-->
-            <!-- wp:query-pagination-numbers {"midSize":1,"className":"page-numbers"} /-->
-            <!-- wp:query-pagination-next {"label":"<?php echo esc_html(__('Next', 'amnesty')); ?>"} /-->
-        <!-- /wp:query-pagination -->
-    <?php endif; ?>
+    <!-- wp:query-pagination {"align":"center","className":"section section--small","paginationArrow":"none","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+        <!-- wp:query-pagination-previous {"label":"<?php echo esc_html(__('Previous', 'amnesty')); ?>"} /-->
+        <!-- wp:query-pagination-numbers {"midSize":1,"className":"page-numbers"} /-->
+        <!-- wp:query-pagination-next {"label":"<?php echo esc_html(__('Next', 'amnesty')); ?>"} /-->
+    <!-- /wp:query-pagination -->
 </div>
 <!-- /wp:query -->

--- a/wp-content/themes/humanity-theme/patterns/countries-list.php
+++ b/wp-content/themes/humanity-theme/patterns/countries-list.php
@@ -18,6 +18,8 @@ $all_countries = new WP_Query($args);
 $doc_id = get_option('countries_global_document_id');
 $doc_url = $doc_id ? wp_get_attachment_url($doc_id) : '';
 
+$chapo_text = get_option('countries_global_chapo', '');
+
 $countries_by_letter = [];
 
 if ($all_countries->have_posts()) {
@@ -39,6 +41,12 @@ if ($all_countries->have_posts()) {
 }
 
 ?>
+
+<?php if (!empty($chapo_text)) : ?>
+    <div class="chapo">
+        <p class="text"><?php echo wp_kses_post(nl2br(stripslashes($chapo_text))); ?></p>
+    </div>
+<?php endif; ?>
 
 <div class="az-filter">
     <h2 class="title">Pays de A à Z</h2>

--- a/wp-content/themes/humanity-theme/templates/page-pays.html
+++ b/wp-content/themes/humanity-theme/templates/page-pays.html
@@ -1,0 +1,12 @@
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group page-standard page-pays">
+    <!-- wp:pattern {"slug":"amnesty/page-hero"} /-->
+    <!-- wp:group {"tagName":"div","className":"container page-container has-gutter","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group container page-container has-gutter">
+        <!-- wp:pattern {"slug":"amnesty/countries-list"} /-->
+    </div>
+    <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"humanity-theme","area":"footer","className":"amnesty-footer-template-part"} /-->


### PR DESCRIPTION
[SEO - suppression balise next page listes](https://linear.app/les-tilleuls/issue/MAINT-240)

Supprime la pagination vestigiale de /pays/ (et le rel=next associe) en passant le modele d'archive fiche_pays a une Page WP statique.

- countries.php: has_archive => false (libere /pays/ pour la Page)
- page-pays.html: template FSE (page-hero + countries-list + footer)
- countries-list.php: rend le chapo countries_global_chapo
- archive-loop.php: retire la branche morte fiche_pays
- seo/base.php: desactive rel=next/prev sur la taxo location

Etape ops au deploiement: creer la Page slug 'pays' + wp rewrite flush.

<img width="1841" height="1251" alt="image" src="https://github.com/user-attachments/assets/3f967755-2a24-4229-a54f-2144de7cccac" />

## Comment tester

> [!IMPORTANT]
> Le code seul ne suffit pas : `/pays/` n'est plus une archive. Il faut **créer la Page WP** correspondante, sinon `/pays/` renvoie une 404.

### 1. Créer la Page « Pays » dans le back-office

1. WP Admin → **Pages → Ajouter**.
2. Titre : `Pays`.
3. Ouvrir le panneau de droite **Page → Permalien (Slug)** et forcer le slug à `pays` (l'URL doit être `/pays/`).
   - ⚠️ Le CPT `fiche_pays` utilise déjà le rewrite slug `pays`. Vérifier que WordPress n'a pas suffixé le slug en `pays-2`. Si c'est le cas, le corriger manuellement en `pays`.
4. Laisser le contenu **vide** : tout est rendu par le template (hero + liste A–Z + bloc rapport).
5. **Publier**.

### 2. Vérifier le modèle de page appliqué

1. Toujours dans l'éditeur de la page, panneau **Page → Modèle**.
2. Le modèle doit être **page-pays** (binding automatique par hiérarchie de templates : `templates/page-pays.html` ↔ Page de slug `pays`). Aucune sélection manuelle nécessaire si le slug est bien `pays`.

### 3. Vider les règles de réécriture

Après le changement `has_archive => false` :
- soit **Réglages → Permaliens → Enregistrer les modifications**,
- soit en CLI : `wp rewrite flush`.

Indispensable pour que `/pays/` cesse d'être l'archive du CPT et soit servi par la Page.

### 4. Vérifications front

| Vérification | Attendu |
|---|---|
| `/pays/` | 200 — hero (titre « Pays ») + index A–Z + bloc rapport |
| Titre du hero | aligné à **gauche**, avec gouttière 24px sur mobile (pas collé au bord) |
| `/pays/page/2/` | **404** (plus d'archive paginée) |
| Source HTML de `/pays/` | **aucune** balise `<link rel="next">` / `rel="prev"` |
| `/pays/{slug-pays}` (ex. une fiche pays) | 200 — single fiche_pays toujours OK |
| `/pays/{terme-location}` | 200 — taxonomie `location` toujours OK |

### 5. Vérifier le chapô (optionnel)

1. WP Admin → **Pays → Réglages** : renseigner le champ chapô (`countries_global_chapo`).
2. Recharger `/pays/` → le chapô s'affiche en tête de la liste (sauts de ligne et HTML simple préservés).
