### PR TITLE
fix: affichage modale cookies avec scroll pour les écrans basse résolution

### DIFF
--- a/private/src/styles/import/_main.scss
+++ b/private/src/styles/import/_main.scss
@@ -7,3 +7,42 @@
     object-fit: contain;
   }
 }
+
+[id='onetrust-consent-sdk'] {
+  @media (max-height: 760px) {
+    [id='onetrust-group-container'],
+    .onetrust-group-container {
+      height: auto !important;
+      max-height: none !important;
+    }
+
+    [id='onetrust-policy-text'],
+    [id='ot-pc-content'],
+    .onetrust-policy-text,
+    .ot-pc-content {
+      max-height: 45vh !important;
+      padding-right: 16px !important;
+      overflow-y: auto !important;
+      box-shadow: inset -8px 0 0 var(--wp--preset--color--black);
+      scrollbar-color: var(--wp--preset--color--black) transparent;
+      scrollbar-gutter: stable;
+      scrollbar-width: thin;
+
+      &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background-color: transparent;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: var(--wp--preset--color--black);
+      }
+    }
+  }
+
+  .onetrust-close-btn-handler.banner-close-button.ot-close-link {
+    background-color: var(--wp--preset--color--white) !important;
+  }
+}


### PR DESCRIPTION
## Contexte

Sur les écrans de faible hauteur, la modale OneTrust pouvait dépasser de l’écran ou rendre l’accès aux actions moins confortable.

## Changements

- Ajoute des styles ciblés sur `#onetrust-consent-sdk` pour les viewports bas (`max-height: 760px`).
- Supprime la contrainte de hauteur fixe sur le conteneur OneTrust dans ce contexte.
- Applique le scroll sur le corps de contenu (`#onetrust-policy-text`, `#ot-pc-content`) avec une hauteur max en `vh`, afin de garder le titre et les boutons d’action visibles.
- Ajoute un style de scrollbar cohérent avec la charte.
- Force le fond blanc du bouton de fermeture OneTrust.

Quand la modale dépasse 90vh, on affiche le scroll : 
<img width="843" height="490" alt="Capture d’écran 2026-06-23 à 10 24 26" src="https://github.com/user-attachments/assets/9b9d11a8-aa87-40e3-8531-d4e6dcdf3424" />
