### PR TITLE
fix: accepter chroniques et chronique pour les attributs de style

### DIFF
--- a/private/src/scripts/editor/blocks/articles-homepage/EditComponent.jsx
+++ b/private/src/scripts/editor/blocks/articles-homepage/EditComponent.jsx
@@ -139,6 +139,7 @@ const EditComponent = ({ attributes, setAttributes }) => {
         return 'Voir toutes les actualités';
       case 'campagnes':
         return 'Voir toutes les campagnes';
+      case 'chronique':
       case 'chroniques':
         return 'Voir tous les articles la chronique';
       case 'dossiers':

--- a/private/src/scripts/editor/blocks/slider/EditComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/EditComponent.jsx
@@ -11,6 +11,7 @@ const seeAll = (categorySlug) => {
       return 'Voir toutes les actualités';
     case 'campagnes':
       return 'Voir toutes les campagnes';
+    case 'chronique':
     case 'chroniques':
       return 'Voir tous les articles la chronique';
     case 'dossiers':

--- a/private/src/scripts/editor/components/ChipCategory.jsx
+++ b/private/src/scripts/editor/components/ChipCategory.jsx
@@ -17,6 +17,7 @@ const ChipCategory = ({ item }) => {
   let styleClass = '';
   switch (slug) {
     case 'actualites':
+    case 'chronique':
     case 'chroniques':
     case 'reperes':
       styleClass = 'bg-yellow';

--- a/wp-content/themes/humanity-theme/includes/blocks/articles-homepage/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/articles-homepage/render.php
@@ -162,7 +162,7 @@ if (!function_exists('render_articles_homepage_block')) {
             }
 
             $chip_style = match ($entity_slug) {
-                'actualites', 'chroniques', 'landmark', 'actualities-my-space' => 'bg-yellow',
+                'actualites', 'chronique', 'chroniques', 'landmark', 'actualities-my-space' => 'bg-yellow',
                 'dossiers', 'campagnes' => 'bg-black',
                 default => 'outline-black',
             };
@@ -201,6 +201,7 @@ if (!function_exists('render_articles_homepage_block')) {
                         return 'Voir toutes les actualités';
                     case 'campagnes':
                         return 'Voir toutes les campagnes';
+                    case 'chronique':
                     case 'chroniques':
                         return 'Voir tous les articles la chronique';
                     case 'dossiers':

--- a/wp-content/themes/humanity-theme/includes/blocks/slider/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/slider/render.php
@@ -62,6 +62,7 @@ if (!function_exists('render_slider_block')) {
                 switch ($slug) {
                     case 'actualites': return 'Voir toutes les actualités';
                     case 'campagnes': return 'Voir toutes les campagnes';
+                    case 'chronique':
                     case 'chroniques': return 'Voir tous les articles la chronique';
                     case 'dossiers': return 'Voir tous les dossiers';
                     case 'landmark': return 'Voir tous les repères';

--- a/wp-content/themes/humanity-theme/patterns/post-back-link.php
+++ b/wp-content/themes/humanity-theme/patterns/post-back-link.php
@@ -22,6 +22,7 @@ $link = '';
 $main_category = amnesty_get_a_post_term($post_id);
 $chip_style = match ($main_category->slug ?? '') {
     'actualites', 'dossiers' => 'bg-black',
+    'chronique',
     'chroniques' => 'bg-yellow',
     default => 'bg-black',
 };

--- a/wp-content/themes/humanity-theme/patterns/post-term-list-metadata.php
+++ b/wp-content/themes/humanity-theme/patterns/post-term-list-metadata.php
@@ -20,6 +20,7 @@ $main_category = amnesty_get_a_post_term($post_id);
 
 $default_chip_style = match ($main_category->slug ?? '') {
     'actualites', 'dossiers' => 'bg-yellow',
+    'chronique',
     'chroniques' => 'outline-yellow',
     default => 'outline-black',
 };


### PR DESCRIPTION
# Contexte
Corrige le rendu des chips “La Chronique” lorsque le slug reçu est chronique au singulier.
Le code gérait déjà certains cas avec chroniques, mais la catégorie créée côté thème utilise le slug chronique. Selon le chemin de rendu, le chip pouvait donc tomber dans le style par défaut outline-black au lieu de bg-yellow, notamment sur les remontées d’articles en homepage.

# Changements 
accepte chronique et chroniques dans les mappings de style des chips ;
applique la même tolérance aux libellés “Voir tous les articles la chronique” ;
aligne aussi les aperçus éditeur React pour éviter un écart front/back.