### PR TITLE
fix(tunnel-clh): appliquer les retours front de démo

### DIFF
--- a/private/src/scripts/admin.js
+++ b/private/src/scripts/admin.js
@@ -1,6 +1,7 @@
 import '../styles/admin.scss';
 import './admin/cmb-events';
 import './admin/cmb-term-type';
+import './admin/acf-short-description-counter';
 import './admin/ordered-list-preview';
 import './admin/options-general';
 import './admin/components/IconPickerControl.jsx';

--- a/private/src/scripts/admin/acf-short-description-counter.js
+++ b/private/src/scripts/admin/acf-short-description-counter.js
@@ -1,0 +1,41 @@
+const FIELD_SELECTOR = '#acf-field_6a155b0a8709c';
+const MAX_LENGTH = 1000;
+
+const getCounterText = (value) => `${value.length} / ${MAX_LENGTH} caractères`;
+
+const initShortDescriptionCounter = () => {
+  const textarea = document.querySelector(FIELD_SELECTOR);
+
+  if (!textarea || textarea.dataset.characterCounterInitialised === 'true') {
+    return;
+  }
+
+  const wrapper = textarea.parentElement;
+
+  if (!wrapper) {
+    return;
+  }
+
+  const container = document.createElement('div');
+  const counter = document.createElement('span');
+  container.className = 'amnesty-acf-character-count-wrapper';
+  counter.className = 'amnesty-acf-character-count';
+  counter.setAttribute('aria-live', 'polite');
+
+  textarea.maxLength = MAX_LENGTH;
+  textarea.dataset.characterCounterInitialised = 'true';
+  wrapper.insertBefore(container, textarea);
+  container.appendChild(textarea);
+  container.appendChild(counter);
+
+  counter.textContent = getCounterText(textarea.value);
+  textarea.addEventListener('input', () => {
+    counter.textContent = getCounterText(textarea.value);
+  });
+};
+
+document.addEventListener('DOMContentLoaded', initShortDescriptionCounter);
+
+if (window.acf) {
+  window.acf.addAction('append', initShortDescriptionCounter);
+}

--- a/private/src/scripts/admin/acf-short-description-counter.js
+++ b/private/src/scripts/admin/acf-short-description-counter.js
@@ -1,36 +1,42 @@
-const FIELD_SELECTOR = '#acf-field_6a155b0a8709c';
+const FIELD_SELECTOR = '.acf-field[data-name="short_description"] textarea';
 const MAX_LENGTH = 1000;
 
 const getCounterText = (value) => `${value.length} / ${MAX_LENGTH} caractères`;
 
 const initShortDescriptionCounter = () => {
-  const textarea = document.querySelector(FIELD_SELECTOR);
+  const textareas = document.querySelectorAll(FIELD_SELECTOR);
 
-  if (!textarea || textarea.dataset.characterCounterInitialised === 'true') {
+  if (!textareas.length) {
     return;
   }
 
-  const wrapper = textarea.parentElement;
+  textareas.forEach((textarea) => {
+    if (textarea.dataset.characterCounterInitialised === 'true') {
+      return;
+    }
 
-  if (!wrapper) {
-    return;
-  }
+    const wrapper = textarea.parentElement;
 
-  const container = document.createElement('div');
-  const counter = document.createElement('span');
-  container.className = 'amnesty-acf-character-count-wrapper';
-  counter.className = 'amnesty-acf-character-count';
-  counter.setAttribute('aria-live', 'polite');
+    if (!wrapper) {
+      return;
+    }
 
-  textarea.maxLength = MAX_LENGTH;
-  textarea.dataset.characterCounterInitialised = 'true';
-  wrapper.insertBefore(container, textarea);
-  container.appendChild(textarea);
-  container.appendChild(counter);
+    const container = document.createElement('div');
+    const counter = document.createElement('span');
+    container.className = 'amnesty-acf-character-count-wrapper';
+    counter.className = 'amnesty-acf-character-count';
+    counter.setAttribute('aria-live', 'polite');
 
-  counter.textContent = getCounterText(textarea.value);
-  textarea.addEventListener('input', () => {
+    textarea.maxLength = MAX_LENGTH;
+    textarea.dataset.characterCounterInitialised = 'true';
+    wrapper.insertBefore(container, textarea);
+    container.appendChild(textarea);
+    container.appendChild(counter);
+
     counter.textContent = getCounterText(textarea.value);
+    textarea.addEventListener('input', () => {
+      counter.textContent = getCounterText(textarea.value);
+    });
   });
 };
 

--- a/private/src/styles/admin.scss
+++ b/private/src/styles/admin.scss
@@ -3,6 +3,31 @@
 @import 'admin/localisation-options';
 @import 'admin/icon-picker-control';
 
+.amnesty-acf-character-count-wrapper {
+  display: block;
+  position: relative;
+  width: 100%;
+
+  textarea {
+    box-sizing: border-box;
+    display: block;
+    width: 100%;
+    padding-bottom: 28px;
+  }
+}
+
+.amnesty-acf-character-count {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  padding: 2px 4px;
+  background-color: #fff;
+  color: #646970;
+  font-size: 12px;
+  line-height: 1.4;
+  pointer-events: none;
+}
+
 :root {
   --ms-base: 16;
   --ms-ratio: 1.2;

--- a/private/src/styles/pages/page/type/_tunnel-clh.scss
+++ b/private/src/styles/pages/page/type/_tunnel-clh.scss
@@ -230,7 +230,7 @@
 
   &-media {
     order: -1;
-    height: 300px;
+    height: 250px;
     margin: 20px 20px 0;
     overflow: hidden;
 
@@ -254,6 +254,10 @@
     font-weight: bold;
     line-height: 1.15;
     text-transform: uppercase;
+
+    @media (max-width: $container-sm) {
+      text-transform: none;
+    }
   }
 
   &-description {

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -1125,7 +1125,7 @@ add_action('acf/include_fields', function () {
                     'id' => '',
                 ],
                 'default_value' => '',
-                'maxlength' => '',
+                'maxlength' => 1000,
                 'allow_in_bindings' => 0,
                 'rows' => '',
                 'placeholder' => '',


### PR DESCRIPTION
## Contexte

Cette PR applique les retours front de démo sur le tunnel CLH.

## Changements

- Ajout d’une limite de 1000 caractères sur le champ ACF de description courte des pétitions.
- Ajout d’un compteur de caractères dans l’admin pour ce champ.
- Ajustement de l’affichage du média dans le tunnel CLH.
- Désactivation de l'uppercase du titre sur mobile pour améliorer la lisibilité.
