### PR TITLE
fix: erreur linter sur le champ short_description

### DIFF
--- a/private/src/scripts/admin/acf-short-description-counter.js
+++ b/private/src/scripts/admin/acf-short-description-counter.js
@@ -27,8 +27,8 @@ const initShortDescriptionCounter = () => {
     counter.className = 'amnesty-acf-character-count';
     counter.setAttribute('aria-live', 'polite');
 
-    textarea.maxLength = MAX_LENGTH;
-    textarea.dataset.characterCounterInitialised = 'true';
+    textarea.setAttribute('maxlength', MAX_LENGTH);
+    textarea.setAttribute('data-character-counter-initialised', 'true');
     wrapper.insertBefore(container, textarea);
     container.appendChild(textarea);
     container.appendChild(counter);


### PR DESCRIPTION
corrige ces erreurs de lint : ERROR in [eslint] 
/Users/justine/Code/amnesty/website/private/src/scripts/admin/acf-short-description-counter.js
  30:5  error  Assignment to property of function parameter 'textarea'  no-param-reassign
  31:5  error  Assignment to property of function parameter 'textarea'  no-param-reassign