### PR TITLE
fix: retrait de la max length bloquante sur le champ short description

### DIFF
--- a/private/src/scripts/admin/acf-short-description-counter.js
+++ b/private/src/scripts/admin/acf-short-description-counter.js
@@ -1,7 +1,16 @@
 const FIELD_SELECTOR = '.acf-field[data-name="short_description"] textarea';
 const MAX_LENGTH = 1000;
 
-const getCounterText = (value) => `${value.length} / ${MAX_LENGTH} caractères`;
+const updateCounter = (counter, value) => {
+  const currentCount = counter.querySelector('.amnesty-acf-character-count-current');
+
+  if (!currentCount) {
+    return;
+  }
+
+  currentCount.textContent = value.length;
+  currentCount.classList.toggle('is-over-limit', value.length > MAX_LENGTH);
+};
 
 const initShortDescriptionCounter = () => {
   const textareas = document.querySelectorAll(FIELD_SELECTOR);
@@ -23,19 +32,23 @@ const initShortDescriptionCounter = () => {
 
     const container = document.createElement('div');
     const counter = document.createElement('span');
+    const currentCount = document.createElement('span');
     container.className = 'amnesty-acf-character-count-wrapper';
     counter.className = 'amnesty-acf-character-count';
+    currentCount.className = 'amnesty-acf-character-count-current';
     counter.setAttribute('aria-live', 'polite');
 
-    textarea.setAttribute('maxlength', MAX_LENGTH);
+    textarea.removeAttribute('maxlength');
     textarea.setAttribute('data-character-counter-initialised', 'true');
     wrapper.insertBefore(container, textarea);
     container.appendChild(textarea);
+    counter.appendChild(currentCount);
+    counter.append(` / ${MAX_LENGTH} caractères`);
     container.appendChild(counter);
 
-    counter.textContent = getCounterText(textarea.value);
+    updateCounter(counter, textarea.value);
     textarea.addEventListener('input', () => {
-      counter.textContent = getCounterText(textarea.value);
+      updateCounter(counter, textarea.value);
     });
   });
 };

--- a/private/src/styles/admin.scss
+++ b/private/src/styles/admin.scss
@@ -28,6 +28,10 @@
   pointer-events: none;
 }
 
+.amnesty-acf-character-count-current.is-over-limit {
+  color: #d63638;
+}
+
 :root {
   --ms-base: 16;
   --ms-ratio: 1.2;

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -1125,7 +1125,7 @@ add_action('acf/include_fields', function () {
                     'id' => '',
                 ],
                 'default_value' => '',
-                'maxlength' => 1000,
+                'maxlength' => '',
                 'allow_in_bindings' => 0,
                 'rows' => '',
                 'placeholder' => '',


### PR DESCRIPTION
# Contexte
Cette PR rend la limite de 1000 caractères de la description courte ACF purement indicative.

# Changements
Suppression du blocage maxlength côté champ ACF short_description.
Suppression explicite de l’attribut maxlength côté JS admin au cas où il serait déjà présent dans le DOM.
Conservation du compteur x / 1000 caractères.
Passage du nombre courant en rouge lorsque la description dépasse 1000 caractères.

<img width="1480" height="192" alt="Capture d’écran 2026-06-25 à 15 10 10" src="https://github.com/user-attachments/assets/297389ef-3378-4bbd-a4a7-f26e98f522b4" />
