### PR TITLE
fix(events): require only city for event location, fix national exemption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "phpstan/phpstan": "^2.2",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "php-stubs/wp-cli-stubs": "2.12.0",
-    "phpunit/phpunit": "^11.5"
+    "phpunit/phpunit": "^11.5",
+    "php-stubs/acf-pro-stubs": "^6.8"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87354b5a230873140d1a68633145f563",
+    "content-hash": "02b6e94df32a61bffd6f0b95ee6080db",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -1545,6 +1545,58 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/acf-pro-stubs",
+            "version": "v6.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/acf-pro-stubs.git",
+                "reference": "b22454992d9651cd837439a2c1073a0955b68d94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/acf-pro-stubs/zipball/b22454992d9651cd837439a2c1073a0955b68d94",
+                "reference": "b22454992d9651cd837439a2c1073a0955b68d94",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "php": "~7.1 || ^8.0",
+                "php-stubs/generator": "^0.8",
+                "phpdocumentor/reflection-docblock": "^5.3"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "extra": {
+                "installer-paths": {
+                    "source/{$name}/": [
+                        "type:wordpress-plugin"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Advanced Custom Fields PRO stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/acf-pro-stubs",
+            "keywords": [
+                "PHPStan",
+                "acf",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/acf-pro-stubs/issues",
+                "source": "https://github.com/php-stubs/acf-pro-stubs/tree/v6.8.2"
+            },
+            "time": "2026-06-01T12:08:34+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",

--- a/wp-content/themes/humanity-theme/includes/admin/event-national.php
+++ b/wp-content/themes/humanity-theme/includes/admin/event-national.php
@@ -58,20 +58,3 @@ add_action(
         );
     }
 );
-
-add_action('save_post', 'set_event_national', 20, 1);
-
-function set_event_national($post_id): void
-{
-    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-        return;
-    }
-
-    $event = get_post($post_id);
-
-    $is_national = get_field('event_national', $post_id);
-
-    if ($is_national) {
-        update_post_meta($post_id, 'event_national', $event->ID);
-    }
-}

--- a/wp-content/themes/humanity-theme/includes/admin/event-require-address.php
+++ b/wp-content/themes/humanity-theme/includes/admin/event-require-address.php
@@ -60,7 +60,7 @@ function enforce_event_address(int $post_id): void
         return;
     }
 
-    if ('1' === get_post_meta($post_id, '_EventNational', true)) {
+    if (get_field('_EventNational', $post_id)) {
         return;
     }
 

--- a/wp-content/themes/humanity-theme/includes/admin/event-require-address.php
+++ b/wp-content/themes/humanity-theme/includes/admin/event-require-address.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  * @var string[]
  */
 const AIF_REQUIRED_VENUE_ADDRESS_FIELDS = [
-    '_VenueAddress',
     '_VenueCity',
     // '_VenueZip', // code postal non requis : souvent absent (intégré à l'adresse).
 ];
@@ -61,7 +60,7 @@ function enforce_event_address(int $post_id): void
         return;
     }
 
-    if (get_post_meta($post_id, 'event_national', true)) {
+    if ('1' === get_post_meta($post_id, '_EventNational', true)) {
         return;
     }
 
@@ -126,7 +125,7 @@ function show_event_address_error_notice(): void
     printf(
         '<div class="notice notice-error is-dismissible"><p>%s</p></div>',
         esc_html__(
-            'L\'adresse du lieu (rue et ville) est obligatoire pour publier un évènement. L\'évènement a été enregistré en brouillon.',
+            'La ville du lieu est obligatoire pour publier un évènement. L\'évènement a été enregistré en brouillon.',
             'humanity'
         )
     );


### PR DESCRIPTION
Un évènement peut désormais être publié avec une ville seule (rue optionnelle), une adresse complète, ou en national. Avant, la rue ET la ville étaient toutes deux obligatoires.

L'exemption "national" était cassée : enforce_event_address lisait le meta `event_national`, jamais rempli. Le champ ACF canonique est `_EventNational` (true_false = 1), utilisé partout ailleurs (SQL agenda, event-card). La fonction set_event_national tentait de synchroniser un meta dérivé via get_field('event_national') (mauvais nom) en stockant l'ID du post — bug présent depuis la création du fichier. Conséquence : un évènement national sans lieu était quand même forcé en brouillon.

- event-require-address.php: champs requis réduits à _VenueCity ; exemption national lue depuis le meta _EventNational ; notice « rue et ville » → « ville »
- event-national.php: suppression du sync set_event_national (mort + redondant, ACF persiste _EventNational nativement)