### PR TITLE
fix(petition): only create Salesforce record on publish

### DIFF
--- a/wp-content/themes/humanity-theme/includes/petitions/create-petition.php
+++ b/wp-content/themes/humanity-theme/includes/petitions/create-petition.php
@@ -8,6 +8,12 @@ function create_petition(int $post_id)
         return;
     }
 
+    // Only create the petition in Salesforce once the post is published, so that
+    // draft/autosave "save" actions don't generate duplicate Salesforce records.
+    if ($post->post_status !== 'publish') {
+        return;
+    }
+
     $ext_id = get_field('uidsf', $post_id);
 
     if ($ext_id) {


### PR DESCRIPTION
The create_petition() handler was hooked on acf/save_post without any post status check, so every draft save (and autosave) triggered a Salesforce petition creation, producing duplicate records. The WP post ended up reusing the SF ID and code origine of the last record created.

Guard the creation so it only runs when the post is published, avoiding duplicates while still relying on the existing uidsf check to prevent re-creation on subsequent edits.

Ref: MAINT-256