### PR TITLE
fix(e2e): avoid waiting for third-party trackers

### DIFF
--- a/private/tests/e2e/support/fixtures.mjs
+++ b/private/tests/e2e/support/fixtures.mjs
@@ -5,7 +5,7 @@ export { expect };
 export const test = base.extend({
   gotoWithoutCookieOverlay: async ({ page }, use) => {
     await use(async (path) => {
-      await page.goto(path);
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
       await page.addStyleTag({
         content: `
           #onetrust-consent-sdk,


### PR DESCRIPTION
## Contexte

Le job Frontend Checks peut timeouter dans les tests Playwright Turnstile sur `page.goto(..., waiting until "load")` lorsque des scripts tiers gardent l'evenement `load` en attente.

Le meme correctif avait deja ete applique sur `sprint/tunnel-clh` via le commit `1aeeb602e691c828dafd2b952cec4b7ac9de412d`. Le probleme etait encore present sur `main` et pouvait bloquer des PRs ciblant `main`.

## Correction

- Remplace l'attente implicite `load` par `domcontentloaded` dans le helper E2E `gotoWithoutCookieOverlay`.
- Conserve le masquage de l'overlay cookie apres navigation.

## Verifications

- `git diff --check origin/main...HEAD`
- `runlog yarn env:e2e:start`
- `runlog yarn test:e2e --grep "forgot password Turnstile server-side flow"` : 4 passed
- `runlog yarn env:e2e:stop`
