### PR TITLE
fix(seo): redirect unpublished country pages to /pays

### DIFF
--- a/fix-broken-links-maint-229.php
+++ b/fix-broken-links-maint-229.php
@@ -117,7 +117,8 @@ function maint229_resolve_country_url( string $country ): ?string {
 /**
  * Construit la table de remplacement CAT 2 : ancienne URL `?p=ID...` => chemin résolu
  * (`/pays/{slug}/`, relatif au host pour préserver le domaine du contenu).
- * Logge les pays non résolus (fiche pays absente) afin de les traiter manuellement.
+ * Les pays sans fiche publiée (brouillon ou absente) sont redirigés vers la page
+ * liste `/pays/` en attendant publication, et loggés comme fallback.
  *
  * @return array{0: array<string,string>, 1: array<int,string>}
  */
@@ -129,8 +130,9 @@ function maint229_build_country_map( array $anchors, $log_file ): array {
 		$url = maint229_resolve_country_url( $country );
 
 		if ( null === $url ) {
-			$unresolved[ $id ] = $country;
-			fwrite( $log_file, "  [CAT2][NON RÉSOLU] p=$id ($country) : aucune fiche pays publiée trouvée." . PHP_EOL );
+			$unresolved[ $id ]   = $country;
+			$map[ (string) $id ] = '/pays/';
+			fwrite( $log_file, "  [CAT2][FALLBACK] p=$id ($country) : fiche non publiée — redirigé vers /pays/." . PHP_EOL );
 			continue;
 		}
 
@@ -406,7 +408,7 @@ $write_failures = 0;
 WP_CLI::line( 'Résolution des fiches pays (CAT 2)...' );
 fwrite( $log_file, '--- Résolution CAT 2 ---' . PHP_EOL );
 [ $cat2_map, $cat2_unresolved ] = maint229_build_country_map( $cat2_country_anchors, $log_file );
-WP_CLI::line( sprintf( '  %d fiches pays résolues, %d non résolues.', count( $cat2_map ), count( $cat2_unresolved ) ) );
+WP_CLI::line( sprintf( '  %d fiches pays résolues, dont %d en fallback vers /pays/.', count( $cat2_map ), count( $cat2_unresolved ) ) );
 
 fwrite( $log_file, '--- Posts modifiés ---' . PHP_EOL );
 
@@ -496,7 +498,7 @@ WP_CLI::line( "$terms_scanned termes analysés, $terms_updated descriptions à c
 WP_CLI::line( $summary );
 
 if ( $cat2_unresolved ) {
-	WP_CLI::warning( 'Fiches pays non résolues (à traiter manuellement) : ' . implode( ', ', $cat2_unresolved ) );
+	WP_CLI::warning( 'Fiches pays non publiées, liens redirigés vers /pays/ en attendant publication : ' . implode( ', ', $cat2_unresolved ) );
 }
 
 if ( $fix_links_live ) {

--- a/wp-content/themes/humanity-theme/includes/helpers/query-filters.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/query-filters.php
@@ -44,7 +44,7 @@ add_filter('the_posts', function ($posts, $query) {
             $term = get_queried_object();
             if ($term) {
                 $pays_post = get_page_by_path($term->slug, OBJECT, 'fiche_pays');
-                if ($pays_post) {
+                if ($pays_post && 'publish' === $pays_post->post_status) {
                     array_unshift($posts, $pays_post);
                     $query->_fiche_pays_injectee = true;
                 }
@@ -55,7 +55,7 @@ add_filter('the_posts', function ($posts, $query) {
             $term = get_queried_object();
             if ($term) {
                 $combat_page = get_page_by_path('nous-connaitre/nos-combats/' . $term->slug);
-                if ($combat_page) {
+                if ($combat_page && 'publish' === $combat_page->post_status) {
                     array_unshift($posts, $combat_page);
                     $query->_fiche_combat_injectee = true;
                 }


### PR DESCRIPTION
## Contexte (MAINT-229)

Le script `fix-broken-links-maint-229.php` a été joué en live, mais 6 fiches pays (Hong Kong, Jamaïque, Liberia, Brunéi Darussalam, Nauru, Luxembourg) ne sont pas publiées (brouillon ou absentes) : leurs anciens liens `?p=ID&post_type=fiche_pays` restaient donc en 404.

Par ailleurs, les pages catégorie (`/categorie/<pays>/`) affichaient la carte de la fiche pays même en brouillon, avec un lien 404 pour les visiteurs. Le contournement actuel (suppression des catégories concernées dans le BO) ne protège pas contre un futur passage en brouillon.

## Changements

### Script de réécriture des liens (`fix-broken-links-maint-229.php`)

- `maint229_build_country_map()` : pays sans fiche publiée → lien réécrit vers la page liste `/pays/` (fallback) au lieu d'être ignoré.
- Log dédié : `[CAT2][FALLBACK] p=ID (Pays) : fiche non publiée — redirigé vers /pays/.`
- Warning et compteur console reformulés en conséquence.

### Fix racine : archives catégorie (`includes/helpers/query-filters.php`)

- Le filtre `the_posts` injecte la fiche pays en tête des archives `location` via `get_page_by_path()`, qui retourne aussi les brouillons/privés → carte visible avec lien 404.
- Injection désormais conditionnée à `post_status === 'publish'`, pour la fiche pays et la page combat (même faille sur `/categorie/<combat>/`).
- Effet : un pays repassé en brouillon disparaît automatiquement de sa page catégorie, plus besoin de supprimer la catégorie dans le BO.

## Vérifications

- `php -l` OK, php-cs-fixer OK, dry-run local OK.
- Fallback testé avec un pays inexistant sur une copie du script : mapping `/pays/` + log FALLBACK corrects.
- Regex vérifiée : `https://www.amnesty.fr/?p=8660&amp;post_type=fiche_pays` → `https://www.amnesty.fr/pays/` (host préservé, encodages `&` gérés).
- `https://www.amnesty.fr/pays/` répond 200.

## À noter avant le run prod

Le run live précédent affichait **CAT2 : 0** remplacements, y compris pour les 23 pays résolus. Faire un dry-run d'abord ; si CAT2 reste à 0, les 404 vivent ailleurs (posts draft, metas, menus…) et il faudra investiguer.

Refs MAINT-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)