### PR TITLE
feat(video-block): support des vidéos MP4 auto-hébergées

### DIFF
--- a/private/src/scripts/editor/blocks/video/EditComponent.jsx
+++ b/private/src/scripts/editor/blocks/video/EditComponent.jsx
@@ -1,6 +1,6 @@
 const { __ } = wp.i18n;
-const { useBlockProps, InspectorControls } = wp.blockEditor;
-const { PanelBody, TextControl } = wp.components;
+const { useBlockProps, InspectorControls, MediaUpload, MediaUploadCheck } = wp.blockEditor;
+const { PanelBody, TextControl, Button } = wp.components;
 
 /**
  * Extract YouTube video ID from various URL formats.
@@ -24,6 +24,18 @@ const getYouTubeEmbedUrl = (url) => {
   }
 };
 
+/**
+ * Detect a self-hosted video file (mp4, webm, ...) from its URL.
+ */
+const isSelfHostedVideo = (url) => {
+  try {
+    const { pathname } = new URL(url);
+    return /\.(mp4|webm|ogv|ogg|mov|m4v)$/i.test(pathname);
+  } catch (e) {
+    return false;
+  }
+};
+
 const EditComponent = (props) => {
   const { attributes, setAttributes } = props;
   const { url, title } = attributes;
@@ -36,14 +48,32 @@ const EditComponent = (props) => {
     setAttributes({ title: value });
   };
 
+  const onSelectMedia = (media) => {
+    setAttributes({ url: media.url });
+  };
+
+  const selfHosted = isSelfHostedVideo(url);
   const embedUrl = getYouTubeEmbedUrl(url);
 
   return (
     <>
       <InspectorControls>
         <PanelBody title={__('Paramètres de la vidéo', 'amnesty')}>
+          <MediaUploadCheck>
+            <MediaUpload
+              onSelect={onSelectMedia}
+              allowedTypes={['video']}
+              render={({ open }) => (
+                <Button onClick={open} isPrimary style={{ marginBottom: '12px' }}>
+                  {url
+                    ? __('Changer la vidéo (médiathèque)', 'amnesty')
+                    : __('Choisir une vidéo (médiathèque)', 'amnesty')}
+                </Button>
+              )}
+            />
+          </MediaUploadCheck>
           <TextControl
-            label="URL de la vidéo (YouTube, Vimeo, MP4...)"
+            label="URL de la vidéo (YouTube ou fichier MP4)"
             value={url}
             onChange={onURLChange}
             placeholder="https://..."
@@ -61,14 +91,18 @@ const EditComponent = (props) => {
       <div {...useBlockProps()} className="video-block">
         {url ? (
           <div className="video-wrapper">
-            <iframe
-              src={embedUrl}
-              width="100%"
-              frameBorder="0"
-              allow="autoplay; encrypted-media"
-              allowFullScreen
-              style={{ pointerEvents: 'none' }}
-            />
+            {selfHosted ? (
+              <video src={url} width="100%" controls style={{ pointerEvents: 'none' }} />
+            ) : (
+              <iframe
+                src={embedUrl}
+                width="100%"
+                frameBorder="0"
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+                style={{ pointerEvents: 'none' }}
+              />
+            )}
           </div>
         ) : (
           <p>Aucune vidéo sélectionnée.</p>

--- a/wp-content/themes/humanity-theme/includes/blocks/video/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/video/render.php
@@ -30,6 +30,25 @@ if (!function_exists('render_video_block')) {
     }
 
     /**
+     * Detect a self-hosted video file (mp4, webm, ...) from its URL.
+     *
+     * @param string $url The video URL.
+     * @return bool
+     */
+    function is_self_hosted_video(string $url): bool
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+
+        if (!is_string($path)) {
+            return false;
+        }
+
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        return in_array($extension, ['mp4', 'webm', 'ogv', 'ogg', 'mov', 'm4v'], true);
+    }
+
+    /**
      * Render the Amnesty Video block
      *
      * @param array<string, mixed> $attributes Block attributes
@@ -43,6 +62,27 @@ if (!function_exists('render_video_block')) {
 
         if (empty($video_url)) {
             return '<p>' . esc_html__('Aucune vidéo sélectionnée', 'amnesty') . '</p>';
+        }
+
+        if (is_self_hosted_video($video_url)) {
+            ob_start();
+            ?>
+
+            <div class="video-block">
+                <div class="video-wrapper">
+                    <video width="100%" controls preload="metadata" src="<?php echo esc_url($video_url); ?>">
+                        <?php echo esc_html__('Votre navigateur ne peut pas lire cette vidéo.', 'amnesty'); ?>
+                    </video>
+                </div>
+                <?php if (!empty($video_title)): ?>
+                    <p class="video-title">
+                        <span class="video-label">Vidéo : </span><?php echo esc_html($video_title); ?>
+                    </p>
+                <?php endif; ?>
+            </div>
+
+            <?php
+            return ob_get_clean();
         }
 
         $video_id = extract_youtube_id($video_url);


### PR DESCRIPTION
Ajoute un bouton médiathèque dans l'éditeur du bloc amnesty-core/video et le rendu <video> pour les fichiers auto-hébergés (mp4, webm, ogv, ogg, mov, m4v), tout en conservant le flux YouTube existant.