### PR TITLE
refactor(clh): fetch campaign petitions via clh_petition flag

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/slider-changez-leur-histoire/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/slider-changez-leur-histoire/render.php
@@ -16,7 +16,7 @@ if (!function_exists('render_slider_changez_leur_histoire_block')) {
         $selected_posts  = [];
 
         if ($active_campaign) {
-            $petitions_list_clh = amnesty_get_clh_campaign_petitions($page_id);
+            $petitions_list_clh = amnesty_get_clh_campaign_petitions();
 
             foreach (array_filter($petitions_list_clh, fn ($p) => amnesty_is_petition_not_expired($p->ID)) as $petition) {
                 $selected_posts[] = ['id' => $petition->ID];

--- a/wp-content/themes/humanity-theme/includes/post-types/clh.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/clh.php
@@ -35,7 +35,7 @@ add_action('acf/include_fields', function () {
                 'aria-label' => '',
                 'type' => 'date_time_picker',
                 'instructions' => '',
-                'required' => 0,
+                'required' => 1,
                 'conditional_logic' => [
                     [
                         [
@@ -75,36 +75,6 @@ add_action('acf/include_fields', function () {
                 'first_day' => 1,
                 'default_to_current_date' => 0,
                 'allow_in_bindings' => 0,
-            ],
-            [
-                'key' => 'field_6a1591cefec3a',
-                'label' => 'Liste des pétitions CLH',
-                'name' => 'list_petition_clh',
-                'aria-label' => '',
-                'type' => 'relationship',
-                'instructions' => '',
-                'required' => 0,
-                'conditional_logic' => [
-                    [
-                        [
-                            'field' => 'field_6a199c4b42f0a',
-                            'operator' => '==',
-                            'value' => '1',
-                        ],
-                    ],
-                ],
-                'wrapper' => ['width' => '', 'class' => '', 'id' => ''],
-                'post_type' => ['petition'],
-                'post_status' => '',
-                'taxonomy' => '',
-                'filters' => ['search'],
-                'return_format' => 'object',
-                'min' => '',
-                'max' => '',
-                'allow_in_bindings' => 0,
-                'elements' => '',
-                'bidirectional' => 1,
-                'bidirectional_target' => '',
             ],
             [
                 'key' => 'field_6a16f00bb9903',
@@ -225,17 +195,3 @@ add_action('acf/include_fields', function () {
         'display_title' => '',
     ]);
 });
-
-add_filter(
-    'acf/fields/relationship/query/name=list_petition_clh',
-    function (array $args): array {
-        $args['meta_query'] = [
-            [
-                'key' => 'clh_petition',
-                'value' => '1',
-                'compare' => '=',
-            ],
-        ];
-        return $args;
-    }
-);

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -266,7 +266,7 @@ if (!function_exists('amnesty_get_clh_petition_campaign_page')) {
 if (!function_exists('amnesty_get_active_clh_campaign_for_page')) {
     function amnesty_get_active_clh_campaign_for_page(int $page_id): ?WP_Post
     {
-        // The CLH campaign fields (highlight_clh, dates, list_petition_clh, share fields) now live
+        // The CLH campaign fields (highlight_clh, dates, share fields) now live
         // directly on the campaign page itself — there is no longer a dedicated `clh` post. The
         // highlight_clh toggle drives activation; when active and within the date window, the page
         // post IS the campaign, so we return it (consumers read the remaining fields via its ID).
@@ -331,68 +331,37 @@ function amnesty_get_active_clh_campaign_petition_ids(): array
     $active_campaign = $clh_page instanceof WP_Post
         ? amnesty_get_active_clh_campaign_for_page((int) $clh_page->ID)
         : null;
-    $list_petitions_clh = $active_campaign ? amnesty_get_clh_campaign_petitions((int) $clh_page->ID) : [];
+    $list_petitions_clh = $active_campaign ? amnesty_get_clh_campaign_petitions() : [];
 
     return $cache = array_map(static fn ($petition) => (int) $petition->ID, $list_petitions_clh);
 }
 
-function amnesty_get_clh_campaign_petitions(int $page_id): array
+function amnesty_get_clh_campaign_petitions(): array
 {
-    $field = get_field_object('field_6a1591cefec3a', $page_id, true, true);
+    static $cache = null;
 
-    if (!is_array($field)) {
-        if (is_admin() || (defined('WP_DEBUG') && WP_DEBUG)) {
-            error_log(sprintf(
-                'Invalid list_petition_clh field configuration for CLH campaign page %d.',
-                $page_id
-            ));
-        }
-
-        return [];
+    if ($cache !== null) {
+        return $cache;
     }
 
-    $petitions = $field['value'] ?? [];
+    $query = new WP_Query([
+        'post_type' => 'petition',
+        'post_status' => 'publish',
+        'posts_per_page' => -1,
+        'no_found_rows' => true,
+        'update_post_term_cache' => false,
+        'orderby' => 'menu_order date',
+        'order' => 'ASC',
+        'meta_query' => [
+            [
+                'key' => 'clh_petition',
+                'value' => '1',
+                'compare' => '=',
+            ],
+        ],
+    ]);
 
-    if (empty($petitions)) {
-        return [];
-    }
-
-    if (!is_array($petitions)) {
-        if (is_admin() || (defined('WP_DEBUG') && WP_DEBUG)) {
-            error_log(sprintf(
-                'Invalid list_petition_clh value for CLH campaign page %d: expected WP_Post array, got %s.',
-                $page_id,
-                gettype($petitions)
-            ));
-        }
-
-        return [];
-    }
-
-    $normalized_petitions = [];
-    $normalized_petition_ids = [];
-
-    foreach ($petitions as $petition) {
-        if (!$petition instanceof WP_Post || $petition->post_type !== 'petition') {
-            continue;
-        }
-
-        if (isset($normalized_petition_ids[$petition->ID])) {
-            continue;
-        }
-
-        $normalized_petitions[] = $petition;
-        $normalized_petition_ids[$petition->ID] = true;
-    }
-
-    if (empty($normalized_petitions) && (is_admin() || (defined('WP_DEBUG') && WP_DEBUG))) {
-        error_log(sprintf(
-            'Invalid list_petition_clh value for CLH campaign page %d: no valid petition found after normalization.',
-            $page_id
-        ));
-    }
-
-    return $normalized_petitions;
+    return $cache = $query->posts;
 }
 
 function amnesty_is_petition_in_active_clh_campaign(int $petition_id): bool
@@ -671,7 +640,7 @@ function amnesty_get_clh_tunnel_context(?WP_Post $post = null): array
     $raw_email = $_SESSION['clh_last_signer_email'] ?? $_COOKIE['clh_user_email'] ?? null;
     $last_signer_email = ($raw_email && is_email($raw_email)) ? sanitize_email($raw_email) : null;
     $current_user = $last_signer_email ? get_local_user($last_signer_email) : false;
-    $list_petitions_clh = $active_campaign ? amnesty_get_clh_campaign_petitions($campaign_page_id) : [];
+    $list_petitions_clh = $active_campaign ? amnesty_get_clh_campaign_petitions() : [];
     $selected_posts = [];
     $skipped_petitions = amnesty_get_clh_skipped_petitions();
     $cookie_signed_ids = $last_signer_email ? [] : amnesty_get_clh_signed_petitions();

--- a/wp-content/themes/humanity-theme/patterns/page-change-their-history-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-change-their-history-content.php
@@ -23,7 +23,7 @@ if ($is_highlighted) {
     $total_number_of_signatures_collected = 0;
     $total_campaign_signatures = 0;
 
-    $list_petition_current_campaign = amnesty_get_clh_campaign_petitions($page->ID);
+    $list_petition_current_campaign = amnesty_get_clh_campaign_petitions();
 
     foreach ($list_petition_current_campaign as $single_campaign) {
         $total_campaign_signatures            += (int) get_post_meta($single_campaign->ID, 'objectif_signatures', true);

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -35,7 +35,7 @@ $last_signer_email = ($raw_email && is_email($raw_email)) ? sanitize_email($raw_
 $current_user = $last_signer_email ? get_local_user($last_signer_email) : false;
 
 $cookie_signed_ids = $last_signer_email ? [] : amnesty_get_clh_signed_petitions();
-$list_petitions_clh = amnesty_get_clh_campaign_petitions((int) $parent);
+$list_petitions_clh = amnesty_get_clh_campaign_petitions();
 
 if (empty($list_petitions_clh)) {
     wp_redirect(amnesty_get_clh_tunnel_end_url());


### PR DESCRIPTION
Replace the removed list_petition_clh relationship field with a WP_Query on the clh_petition boolean: any published petition with the flag enabled now enters the campaign, no manual list to curate. Drop the now-dead ACF relationship filter and the page_id parameter.