### PR TITLE
fix(alert-banner): exclut le script anti-flash de l'optimisation JS 

### DIFF
--- a/wp-content/themes/humanity-theme/partials/alert-banner.php
+++ b/wp-content/themes/humanity-theme/partials/alert-banner.php
@@ -68,7 +68,7 @@ $svg = file_get_contents($template_directory . '/assets/images/icon-cross.svg');
 	</div>
 </div>
 <?php
-printf('<script>%s</script>', amnesty_alert_banner_inline_script()); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+printf('<script data-cfasync="false">%s</script>', amnesty_alert_banner_inline_script()); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 wp_reset_postdata();
 ?>
 


### PR DESCRIPTION
exclut le script anti-flash de l'optimisation JS de Cloudflare

MAINT-161

Cloudflare APO (Automatic Platform Optimization) réécrit et différe l'exécution des scripts inline, ce qui annulait le fix précédent : le script s'exécutait après le paint au lieu d'avant, donc le flash persistait sur preprod/prod malgré le fix en local (pas de Cloudflare devant).

data-cfasync="false" exclut ce script précis du traitement Cloudflare et garantit qu'il reste synchrone, exécuté juste après le markup.