### PR TITLE
perf(analytics) MAINT-278

### DIFF
--- a/wp-content/themes/humanity-theme/includes/theme-setup/analytics/google-tag-manager.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/analytics/google-tag-manager.php
@@ -23,6 +23,7 @@ if (! function_exists('amnesty_output_gtm')) {
         }
 
         wp_enqueue_script('gtm', sprintf('https://www.googletagmanager.com/gtm.js?id=%s', esc_attr($gtm)), [], '1.0.0', false);
+        wp_script_add_data('gtm', 'strategy', 'async');
         wp_add_inline_script('gtm', 'window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)};', 'before');
 
         $consent = amnesty_get_option('gtm_consent_mode', 'amnesty_analytics_options_page');


### PR DESCRIPTION
charger gtm.js en async pour éviter le blocage du rendu

Ajoute la stratégie async au script GTM afin de ne plus bloquer le rendu de la page (critère 5.1 du RGESN), sans retarder l'instant de démarrage du dataLayer/GTM pour préserver le suivi des visiteurs qui quittent la page rapidement.