### PR TITLE
perf-MAINT-275(images): lazy loading and decoding async

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/action/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/action/render.php
@@ -77,7 +77,7 @@ if (!function_exists('render_action_block')) {
                 </div>
                 <?php if (!empty($final_image_url)) : ?>
                     <div class="container-image">
-                        <img class="action-image" src="<?php echo esc_url($final_image_url); ?>" alt="" />
+                        <img class="action-image" src="<?php echo esc_url($final_image_url); ?>" alt="" loading="lazy" decoding="async" />
                     </div>
                 <?php endif; ?>
                 <?php if (!empty($sur_title)) : ?>

--- a/wp-content/themes/humanity-theme/includes/blocks/actions-homepage/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/actions-homepage/render.php
@@ -46,7 +46,7 @@ if (!function_exists('render_actions_homepage_block')) {
                             <div class="item">
                                 <div class="image-wrapper">
                                     <?php if (!empty($imageUrl)) : ?>
-                                        <img class="image" src="<?php echo esc_url($imageUrl); ?>" alt="<?php echo esc_attr($itemTitle); ?>" />
+                                        <img class="image" src="<?php echo esc_url($imageUrl); ?>" alt="<?php echo esc_attr($itemTitle); ?>" loading="lazy" decoding="async" />
                                     <?php else : ?>
                                         <div class="no-image">
                                             <span><?php echo esc_html__('Sélectionnez une image', 'amnesty'); ?></span>

--- a/wp-content/themes/humanity-theme/includes/blocks/agenda-homepage/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/agenda-homepage/render.php
@@ -107,7 +107,7 @@ if (!function_exists('render_agenda_homepage_block')) {
                 <div class="chronicle-card">
                     <div class="chronicle-card-image-container">
                         <?php if (!empty($chronicle_image_url)) : ?>
-                            <img src="<?php echo esc_url($chronicle_image_url); ?>" class="chronicle-card-image" alt="<?php esc_attr_e('Image de La Chronique', 'amnesty-core'); ?>" />
+                            <img src="<?php echo esc_url($chronicle_image_url); ?>" class="chronicle-card-image" alt="<?php esc_attr_e('Image de La Chronique', 'amnesty-core'); ?>" loading="lazy" decoding="async" />
                         <?php endif; ?>
                     </div>
                     <div class="chronicle-card-content">

--- a/wp-content/themes/humanity-theme/includes/blocks/card-image-text/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/card-image-text/render.php
@@ -104,7 +104,7 @@ if (!function_exists('render_card_image_text_block')) {
                 <<?= $editor ? 'div' : 'a' ?> href="<?php echo esc_url($permalink); ?>" class="card-image-text-block-link"<?php echo $link_extra_attrs; ?>>
                     <div class="card-image-text-thumbnail-wrapper">
                         <?php if (!empty($thumbnail_url)) : ?>
-                            <img class="card-image-text-thumbnail" src="<?php echo esc_url($thumbnail_url); ?>" alt="<?php echo esc_attr($title); ?>" />
+                            <img class="card-image-text-thumbnail" src="<?php echo esc_url($thumbnail_url); ?>" alt="<?php echo esc_attr($title); ?>" loading="lazy" decoding="async" />
                         <?php endif; ?>
                     </div>
                     <div class="card-image-text-content-container">

--- a/wp-content/themes/humanity-theme/includes/blocks/carousel/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/carousel/render.php
@@ -35,7 +35,7 @@ if (!function_exists('render_carousel_block')) {
                         ?>
                         <div class="swiper-slide">
                             <div class="carousel-image">
-                                <img src="<?php echo esc_url($image_url); ?>" alt="<?php echo esc_attr($alt); ?>" loading="lazy" />
+                                <img src="<?php echo esc_url($image_url); ?>" alt="<?php echo esc_attr($alt); ?>" loading="lazy" decoding="async" />
                                 <?php if (!empty($caption)) : ?>
                                     <div class="carousel-caption">
                                         <span class="carousel-caption-text"><?php echo wp_kses_post($caption); ?></span>

--- a/wp-content/themes/humanity-theme/includes/blocks/chronicle-card/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/chronicle-card/render.php
@@ -19,7 +19,7 @@ if (!function_exists('render_chronicle_card_block')) {
 
         if ($cover_image && is_array($cover_image)) {
             $cover = sprintf(
-                '<img src="%s" alt="%s" class="chronicle__image" />',
+                '<img src="%s" alt="%s" class="chronicle__image" loading="lazy" decoding="async" />',
                 esc_url($cover_image['sizes']['medium']),
                 esc_attr($cover_image['alt']),
             );

--- a/wp-content/themes/humanity-theme/includes/blocks/image/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/image/render.php
@@ -38,7 +38,7 @@ if (!function_exists('render_image_block')) {
 
         <div class="image-block <?php echo esc_attr($classes) ?> <?php ?>">
             <div class="image-wrapper">
-                <img src="<?php echo esc_url($image_url); ?>" alt="<?php echo esc_attr($alt); ?>" />
+                <img src="<?php echo esc_url($image_url); ?>" alt="<?php echo esc_attr($alt); ?>" loading="lazy" decoding="async" />
                 <?php if (!empty($caption)) : ?>
                     <p class="image-caption"><?php echo esc_html($caption); ?></p>
                 <?php endif; ?>

--- a/wp-content/themes/humanity-theme/includes/blocks/petition-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/petition-list/render.php
@@ -64,7 +64,7 @@ if (! function_exists('amnesty_render_petition_item')) {
         ?>
 		<article class="grid-item petition-item" aria-label="Article: <?php echo esc_attr(format_for_aria_label($title)); ?>" tabindex="0">
 			<figure>
-				<img class="petition-itemImage aiic-ignore" src="<?php echo esc_url($feature); ?>" alt="">
+				<img class="petition-itemImage aiic-ignore" src="<?php echo esc_url($feature); ?>" alt="" loading="lazy" decoding="async">
 				<?php if (! empty($data['tag'])) : ?>
 				<span class="petition-itemImageCaption">
 					<?php

--- a/wp-content/themes/humanity-theme/includes/blocks/quote/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/quote/render.php
@@ -25,7 +25,7 @@ if (!function_exists('render_quote_block')) {
 		<div class="wp-block-amnesty-core-quote-block quote-block">
             <?php if ($show_image && $image_url): ?>
                 <div class="quote-image">
-                    <img src="<?php echo esc_url($image_url); ?>" alt="<?php esc_attr_e('Image de la citation', 'amnesty'); ?>" />
+                    <img src="<?php echo esc_url($image_url); ?>" alt="<?php esc_attr_e('Image de la citation', 'amnesty'); ?>" loading="lazy" decoding="async" />
                 </div>
             <?php endif; ?>
 

--- a/wp-content/themes/humanity-theme/includes/blocks/video/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/video/render.php
@@ -99,7 +99,7 @@ if (!function_exists('render_video_block')) {
         <div class="video-block">
             <div class="video-wrapper">
 				<div class="warning">
-					<img src="<?= $image_broken ?>" alt="warning">
+					<img src="<?= $image_broken ?>" alt="warning" loading="lazy" decoding="async">
 					<p>
 						Le visionnage de cette vidéo entraîne un dépôt de cookies de la part de YouTube. Si vous
 						souhaitez lire la vidéo, vous devez consentir aux cookies pour une publicité ciblée en

--- a/wp-content/themes/humanity-theme/partials/article-card.php
+++ b/wp-content/themes/humanity-theme/partials/article-card.php
@@ -30,7 +30,7 @@ if (!$post_object instanceof WP_Post || $custom) {
 
     if ('press-release' === get_post_type($post_object) && !$thumbnail) {
         $default_image_url = get_template_directory_uri() . '/assets/images/default-press-release-small.png';
-        $thumbnail = '<img src="' . esc_url($default_image_url) . '" alt="' . esc_attr($title) . '" class="article-image">';
+        $thumbnail = '<img src="' . esc_url($default_image_url) . '" alt="' . esc_attr($title) . '" class="article-image" loading="lazy" decoding="async">';
     }
 
     $main_category = amnesty_get_a_post_term($post_id);

--- a/wp-content/themes/humanity-theme/partials/article-share.php
+++ b/wp-content/themes/humanity-theme/partials/article-share.php
@@ -12,12 +12,12 @@ spaceless();
 <ul class="article-share" role="complementary" aria-label="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ Accessibility text */ esc_attr_e('Social sharing options', 'amnesty'); ?>">
 	<li>
 		<a class="article-shareFacebook" target="_blank" rel="noreferrer noopener" href="https://www.facebook.com/sharer.php?u=<?php the_permalink(); ?>" title="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ text shows on hover  */ esc_attr_e('Share on Facebook', 'amnesty'); ?>">
-			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-facebook.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Facebook Logo', 'amnesty'); ?>">
+			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-facebook.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Facebook Logo', 'amnesty'); ?>" loading="lazy" decoding="async">
 		</a>
 	</li>
 	<li>
 		<a class="article-shareTwitter" target="_blank" rel="noreferrer noopener" href="https://twitter.com/intent/tweet?url=<?php the_permalink(); ?>&text=<?php the_title(); ?>" title="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ text shows on hover */ esc_attr_e('Share on Twitter', 'amnesty'); ?>">
-			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-twitter.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Twitter Logo', 'amnesty'); ?>">
+			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-twitter.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Twitter Logo', 'amnesty'); ?>" loading="lazy" decoding="async">
 		</a>
 	</li>
 </ul>

--- a/wp-content/themes/humanity-theme/partials/product/category.php
+++ b/wp-content/themes/humanity-theme/partials/product/category.php
@@ -27,7 +27,7 @@ $aria_label = sprintf( /* translators: [front] ARIA Donate %s: the product categ
 <article class="post postImage--small" role="listitem" aria-label="<?php echo esc_attr($aria_label); ?>">
 	<figure class="post-figure">
 		<a href="<?php echo esc_url($category_link); ?>">
-			<img src="<?php echo esc_url($featured_image); ?>" alt="">
+			<img src="<?php echo esc_url($featured_image); ?>" alt="" loading="lazy" decoding="async">
 		</a>
 	</figure>
 	<div class="post-content">

--- a/wp-content/themes/humanity-theme/patterns/aside-legs-sticky.php
+++ b/wp-content/themes/humanity-theme/patterns/aside-legs-sticky.php
@@ -15,7 +15,7 @@ $icon_phone_url = get_template_directory_uri() . '/assets/images/icon-phone.svg'
 <aside class="page-legs-aside">
   <div class="sticky-card">
     <div class="sticky-card-image-container">
-      <img class="sticky-card-image" src="<?php echo esc_url($image_url); ?>" alt="" />
+      <img class="sticky-card-image" src="<?php echo esc_url($image_url); ?>" alt="" loading="lazy" decoding="async" />
     </div>
     <div class="sticky-card-content">
       <div class="officers">
@@ -24,7 +24,7 @@ $icon_phone_url = get_template_directory_uri() . '/assets/images/icon-phone.svg'
       </div>
       <div class="phone-container">
         <div class="icon-container">
-          <img src="<?php echo esc_url($icon_phone_url); ?>" alt=""/>
+          <img src="<?php echo esc_url($icon_phone_url); ?>" alt="" loading="lazy" decoding="async"/>
         </div>
         <p class="phone">01 53 38 66 24</p>
       </div>

--- a/wp-content/themes/humanity-theme/patterns/attachment-share.php
+++ b/wp-content/themes/humanity-theme/patterns/attachment-share.php
@@ -31,14 +31,14 @@ spaceless();
 <ul class="wp-block-list article-share"><!-- wp:list-item -->
 	<li>
 		<a class="article-shareFacebook" target="_blank" rel="noreferrer noopener" href="https://www.facebook.com/sharer.php?u=<?php the_permalink(); ?>" title="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ text shows on hover  */ esc_attr_e('Share on Facebook', 'amnesty'); ?>">
-			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-facebook.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Facebook Logo', 'amnesty'); ?>">
+			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-facebook.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Facebook Logo', 'amnesty'); ?>" loading="lazy" decoding="async">
 		</a>
 	</li>
 	<!-- /wp:list-item -->
 	<!-- wp:list-item -->
 	<li>
 		<a class="article-shareTwitter" target="_blank" rel="noreferrer noopener" href="https://twitter.com/intent/tweet?url=<?php the_permalink(); ?>&text=<?php the_title(); ?>" title="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ text shows on hover */ esc_attr_e('Share on Twitter', 'amnesty'); ?>">
-			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-twitter.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Twitter Logo', 'amnesty'); ?>">
+			<img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-twitter.svg" alt="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ esc_attr_e('Twitter Logo', 'amnesty'); ?>" loading="lazy" decoding="async">
 		</a>
 	</li>
 <!-- /wp:list-item --></ul>

--- a/wp-content/themes/humanity-theme/patterns/author-bio.php
+++ b/wp-content/themes/humanity-theme/patterns/author-bio.php
@@ -24,7 +24,7 @@ $avatar = get_the_author_meta('authoravatar_id');
 <div class="wp-block-group biography-container u-cf">
 	<?php if ($avatar) : ?>
 	<!-- wp:image {"id":<?php echo absint($avatar); ?>,"aspectRatio":"1","scale":"cover","sizeSlug":"thumbnail","linkDestination":"none","align":"left","hideImageCopyright":true} -->
-	<figure class="wp-block-image alignleft size-thumbnail"><img src="<?php echo esc_url(wp_get_attachment_image_src(absint($avatar))[0]); ?>" alt="" class="wp-image-<?php echo absint($avatar); ?>" style="aspect-ratio:1;object-fit:cover"/></figure>
+	<figure class="wp-block-image alignleft size-thumbnail"><img src="<?php echo esc_url(wp_get_attachment_image_src(absint($avatar))[0]); ?>" alt="" class="wp-image-<?php echo absint($avatar); ?>" style="aspect-ratio:1;object-fit:cover" loading="lazy" decoding="async"/></figure>
 	<!-- /wp:image -->
 	<?php endif; ?>
 	<!-- wp:group {"tagName":"div","className":"author-biography"} -->

--- a/wp-content/themes/humanity-theme/patterns/countries-list.php
+++ b/wp-content/themes/humanity-theme/patterns/countries-list.php
@@ -80,7 +80,7 @@ if ($all_countries->have_posts()) {
         <h3 class="subtitle">UN BILAN DE LA SITUATION DES DROITS HUMAINS DANS 144 PAYS EN 2025</h3>
         <div class="download">
             <div class="icon-container">
-                <img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-download-arrow-dark.svg" alt="Download Icon" />
+                <img src="<?php echo esc_url(amnesty_asset_uri('images')); ?>/icon-download-arrow-dark.svg" alt="Download Icon" loading="lazy" decoding="async" />
             </div>
             <p class="label">
                 <?php if ($doc_url) : ?>

--- a/wp-content/themes/humanity-theme/patterns/form-foundation.php
+++ b/wp-content/themes/humanity-theme/patterns/form-foundation.php
@@ -19,13 +19,13 @@ $icon_phone_url = get_template_directory_uri() . '/assets/images/icon-phone.svg'
         <div class="form-container">
             <div class="officers">
                 <div class="officers-image-container">
-                    <img class="officers-image" src="<?php echo esc_url($image_url); ?>" alt=""/>
+                    <img class="officers-image" src="<?php echo esc_url($image_url); ?>" alt="" loading="lazy" decoding="async"/>
                 </div>
                 <p class="officers-job">Chargée de la relation avec les donatrices et donateurs de la Fondation</p>
                 <p class="officers-names">Milena Djelic</p>
                 <div class="phone-container">
                     <div class="icon-container">
-                        <img src="<?php echo esc_url($icon_phone_url); ?>" alt=""/>
+                        <img src="<?php echo esc_url($icon_phone_url); ?>" alt="" loading="lazy" decoding="async"/>
                     </div>
                     <p class="phone">01 53 38 65 31</p>
                 </div>

--- a/wp-content/themes/humanity-theme/patterns/form-legs.php
+++ b/wp-content/themes/humanity-theme/patterns/form-legs.php
@@ -19,13 +19,13 @@ $icon_phone_url = get_template_directory_uri() . '/assets/images/icon-phone.svg'
         <div class="form-container">
             <div class="officers">
                 <div class="officers-image-container">
-                    <img class="officers-image" src="<?php echo esc_url($image_url); ?>" alt=""/>
+                    <img class="officers-image" src="<?php echo esc_url($image_url); ?>" alt="" loading="lazy" decoding="async"/>
                 </div>
                 <p class="officers-names">Sophie ROUPPERT et Lisa LACOSTE</p>
                 <p class="officers-job">Chargées de relations testateurs</p>
                 <div class="phone-container">
                     <div class="icon-container">
-                        <img src="<?php echo esc_url($icon_phone_url); ?>" alt=""/>
+                        <img src="<?php echo esc_url($icon_phone_url); ?>" alt="" loading="lazy" decoding="async"/>
                     </div>
                     <p class="phone">01 53 38 66 24</p>
                 </div>

--- a/wp-content/themes/humanity-theme/patterns/petition-thanks.php
+++ b/wp-content/themes/humanity-theme/patterns/petition-thanks.php
@@ -189,7 +189,7 @@ if ($random_petition->have_posts()) :
                 <div class="random-petition">
                     <?php if ($featured_image_url) : ?>
                         <div class="random-petition-image-container">
-                            <img class="random-petition-image" src="<?php echo esc_url($featured_image_url); ?>" alt="<?php echo esc_attr($random_title); ?>">
+                            <img class="random-petition-image" src="<?php echo esc_url($featured_image_url); ?>" alt="<?php echo esc_attr($random_title); ?>" loading="lazy" decoding="async">
                         </div>
                     <?php endif; ?>
                     <div class="random-petition-meta">

--- a/wp-content/themes/humanity-theme/patterns/single-chronicle-content.php
+++ b/wp-content/themes/humanity-theme/patterns/single-chronicle-content.php
@@ -39,7 +39,7 @@ if ($is_promo_context) {
 	<div class="chronicle-promo-container">
 		<div class="chronicle-promo__open-magazine">
 			<figure class="open-magazine">
-				<img src="<?php echo esc_url($open_cover_image['sizes']['medium_large']); ?>" alt="<?php echo esc_attr($open_cover_image['alt']); ?>">
+				<img src="<?php echo esc_url($open_cover_image['sizes']['medium_large']); ?>" alt="<?php echo esc_attr($open_cover_image['alt']); ?>" loading="lazy" decoding="async">
 			</figure>
 		</div>
 	</div>
@@ -54,6 +54,7 @@ if ($is_promo_context) {
 		<figure class="cover-image">
 			<img src="<?php echo esc_url($cover_image['sizes']['medium_large']); ?>"
 				 alt="<?php echo esc_attr($cover_image['alt']); ?>"
+				 loading="lazy" decoding="async"
 			/>
 		</figure>
 		<?php endif; ?>


### PR DESCRIPTION
systématiser loading="lazy" et decoding="async" sur les images hors-viewport ([MAINT-275](https://linear.app/les-tilleuls/issue/MAINT-275/systematiser-les-attributs-loadinglazy-et-decodingasync))

Ajoute les attributs sur les balises <img> codées en dur dans les blocs, patterns et partials custom afin d'améliorer le temps de rendu initial des pages et de répondre au critère 4.1 du référentiel RGESN. Les images déjà servies via wp_get_attachment_image() sont couvertes nativement par WordPress et n'ont pas été modifiées. Les images LCP au-dessus du pli (hero homepage, featured image, hero du mon-espace) sont volontairement exclues du lazy-loading.