### PR TITLE
Réactive le seuil des grandes images à l’upload

### DIFF
--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -484,8 +484,6 @@ add_filter(
     2
 );
 
-add_filter('big_image_size_threshold', '__return_false');
-
 add_filter('block_editor_settings_all', function ($settings, $context) {
     if (current_user_can('edit_theme_options')) {
         return $settings;

--- a/wp-content/themes/humanity-theme/includes/theme-setup/media.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/media.php
@@ -33,6 +33,27 @@ if (! function_exists('amnesty_add_jfif_support')) {
     }
 }
 
+if (! defined('AMNESTY_BIG_IMAGE_SIZE_THRESHOLD')) {
+    define('AMNESTY_BIG_IMAGE_SIZE_THRESHOLD', 3200);
+}
+
+if (! function_exists('amnesty_big_image_size_threshold')) {
+    /**
+     * Limit original uploaded images while preserving enough pixels for hero crops.
+     *
+     * The largest registered crop is hero-lg at 2560x710. A 3200px threshold keeps
+     * a 3200x900 source intact, which leaves enough height for that wide crop.
+     *
+     * @package Amnesty\ThemeSetup
+     *
+     * @return int
+     */
+    function amnesty_big_image_size_threshold(): int
+    {
+        return AMNESTY_BIG_IMAGE_SIZE_THRESHOLD;
+    }
+}
+
 if (! function_exists('amnesty_remove_gutenberg_media_options')) {
     /**
      * Remove entries from the "Media" tab in the Gutenberg inserter
@@ -52,6 +73,7 @@ if (! function_exists('amnesty_remove_gutenberg_media_options')) {
 
 add_filter('jpeg_quality', 'amnesty_image_quality');
 add_filter('wp_editor_set_quality', 'amnesty_image_quality');
+add_filter('big_image_size_threshold', 'amnesty_big_image_size_threshold');
 
 remove_filter('the_content', 'prepend_attachment');
 


### PR DESCRIPTION
## Contexte

WordPress permet de limiter automatiquement les très grandes images uploadées via `big_image_size_threshold`, mais le thème désactivait explicitement ce comportement.

## Changements

- Réactive `big_image_size_threshold` pour les uploads médias.
- Définit un seuil explicite à `3200px`.
- Déplace la configuration dans le setup média du thème.
- Supprime la désactivation `__return_false`.

## Note image hero

Le seuil de `3200px` garde une marge suffisante pour les plus grands formats hero existants, notamment `hero-lg` en `2560x710`.

## Vérifications

- `php -l` OK sur les fichiers modifiés.
- Callback vérifié : retourne `3200`.
- PHP-CS-Fixer ciblé OK.