### PR TITLE
fix(sentry): Attempt to read property "post_parent" on null (MAINT-287)

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/page-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-content.php
@@ -16,7 +16,7 @@ if (is_front_page()) {
 $hero_extra_class = ! has_post_thumbnail() ? 'no-featured-image' : '';
 $no_chapo = ! has_block('amnesty-core/chapo') ? 'no-chapo' : '';
 $page = get_post();
-$parent = get_post($page->post_parent);
+$parent = get_post($page?->post_parent);
 //$is_combat_page = $parent && $parent->post_name === 'nos-combats';
 $has_related_content = !empty(get_field('_related_posts_selected', $page));
 ?>


### PR DESCRIPTION
close [MAINT-287](https://linear.app/les-tilleuls/issue/MAINT-287/errorexception-warning-attempt-to-read-property-post-parent-on-null)

**NB :** la correction porte sur la déclaration de la variable `$parent` ligne 19, qui n'est ensuite utilisée que dans une ligne commentée (ligne 20). 
Est-ce qu'il ne vaudrait pas mieux juste supprimer les 2 lignes concernées ?