### PR TITLE
fix(mon-espace): sidebar mobile masquée par la barre du navigateur

### DIFF
--- a/private/src/styles/my-space/_sidebar-menu.scss
+++ b/private/src/styles/my-space/_sidebar-menu.scss
@@ -328,6 +328,12 @@ body.menu-open {
     transform: translateX(-100%);
     transition: transform 0.3s ease-in-out;
 
+    // 100vh = large viewport on mobile Firefox/Safari: the bottom browser bar
+    // covers the sidebar footer ("Mon compte"). dvh follows the visible area.
+    @supports (height: 100dvh) {
+      height: 100dvh;
+    }
+
     &.is-open {
       transform: translateX(0);
     }
@@ -338,6 +344,10 @@ body.menu-open {
       justify-content: center;
       width: 40px;
       height: 40px;
+    }
+
+    .aif-donor-space-sidebar-footer {
+      padding-bottom: calc(16px + env(safe-area-inset-bottom));
     }
   }
 }


### PR DESCRIPTION
## Problème

Sur `patterns/my-space-sidebar.php` en mobile, le lien **« Mon compte »** (footer de la sidebar) se retrouvait sous la barre de navigation basse du navigateur, notamment sur Firefox Android.

Cause : la sidebar mobile utilise `height: 100vh`. Sur Firefox/Safari mobile, `100vh` correspond au *large viewport* (barre d'outils rétractée), donc le bas de la sidebar passe sous la barre visible.

## Correctif

`private/src/styles/my-space/_sidebar-menu.scss` (breakpoint `max-width: $container-md`) :

- `height: 100dvh` via `@supports`, en gardant `100vh` en fallback — `dvh` suit la zone réellement visible. Le `@supports` évite aussi la duplication de propriété refusée par stylelint (`declaration-block-no-duplicate-properties`).
- `padding-bottom: calc(16px + env(safe-area-inset-bottom))` sur `.aif-donor-space-sidebar-footer` pour dégager l'indicateur home iOS.

## Tests

- `yarn lint:styles` : OK
- `yarn build` : OK
- À vérifier en recette : ouverture du menu sur Firefox Android + Safari iOS, le lien « Mon compte » doit rester accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)