### PR TITLE
fix(auth): rediriger la déconnexion vers l’accueil

### DIFF
--- a/wp-content/themes/humanity-theme/includes/my-space/template.php
+++ b/wp-content/themes/humanity-theme/includes/my-space/template.php
@@ -56,6 +56,17 @@ function auth_my_space()
 
 add_action('template_redirect', 'aif_restrict_my_space_access');
 
+add_filter('logout_redirect', 'aif_my_space_logout_redirect', 10, 2);
+
+function aif_my_space_logout_redirect($redirect_to, $requested_redirect_to)
+{
+    if (!empty($requested_redirect_to)) {
+        return $redirect_to;
+    }
+
+    return home_url('/');
+}
+
 function aif_restrict_my_space_access()
 {
     $my_space_parent_slug = 'mon-espace';

--- a/wp-content/themes/humanity-theme/page-se-deconnecter.php
+++ b/wp-content/themes/humanity-theme/page-se-deconnecter.php
@@ -2,5 +2,5 @@
 
 wp_logout();
 
-wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
+wp_safe_redirect(home_url('/'));
 exit;


### PR DESCRIPTION
## Contexte

Le lien `Mon espace > Se déconnecter` renvoyait vers l’URL WordPress native `/wp-login.php?loggedout=true&wp_lang=fr_fr` au lieu de revenir sur le site Amnesty.

## Changements

- Redirige la page `se-deconnecter` vers l’accueil après `wp_logout()`.
- Ajoute un filtre `logout_redirect` pour couvrir aussi les déconnexions WordPress natives sans `redirect_to` explicite.

## Tests

- `php -l wp-content/themes/humanity-theme/page-se-deconnecter.php`
- `php -l wp-content/themes/humanity-theme/includes/my-space/template.php`