### PR TITLE
MAINT-231 fix(seo): restaure et nettoie les canonicals des archives

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,5 +20,8 @@
         <testsuite name="SalesforceSync">
             <directory>tests/SalesforceSync</directory>
         </testsuite>
+        <testsuite name="Seo">
+            <directory>tests/Seo</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Seo/CanonicalTest.php
+++ b/tests/Seo/CanonicalTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Scenario stubs for the WordPress functions canonical.php calls. Values are
+ * driven from the tests through $GLOBALS so each case can pick its own context.
+ */
+if (! function_exists('home_url')) {
+    $GLOBALS['__phpunit_home_url'] = 'https://www.amnesty.fr';
+
+    function home_url(string $path = '', ?string $scheme = null): string
+    {
+        $home = rtrim($GLOBALS['__phpunit_home_url'], '/');
+
+        return '' === $path ? $home : $home . '/' . ltrim($path, '/');
+    }
+}
+
+if (! function_exists('get_option')) {
+    $GLOBALS['__phpunit_options'] = [];
+
+    function get_option(string $option, mixed $default = false): mixed
+    {
+        return $GLOBALS['__phpunit_options'][$option] ?? $default;
+    }
+}
+
+if (! function_exists('get_queried_object_id')) {
+    $GLOBALS['__phpunit_queried_object_id'] = 0;
+
+    function get_queried_object_id(): int
+    {
+        return (int) $GLOBALS['__phpunit_queried_object_id'];
+    }
+}
+
+if (! function_exists('is_paged')) {
+    $GLOBALS['__phpunit_is_paged'] = false;
+
+    function is_paged(): bool
+    {
+        return (bool) $GLOBALS['__phpunit_is_paged'];
+    }
+}
+
+if (! function_exists('current_url')) {
+    $GLOBALS['__phpunit_current_url'] = 'https://www.amnesty.fr/';
+
+    function current_url(): ?string
+    {
+        return $GLOBALS['__phpunit_current_url'];
+    }
+}
+
+require_once __DIR__ . '/../../wp-content/themes/humanity-theme/includes/helpers/string-manipulation.php';
+require_once __DIR__ . '/../../wp-content/themes/humanity-theme/includes/seo/canonical.php';
+
+/**
+ * MAINT-231: canonical URLs must be absolute, on the production host, with a
+ * clean path - and archives must never lose their canonical.
+ */
+final class CanonicalTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['__phpunit_home_url']          = 'https://www.amnesty.fr';
+        $GLOBALS['__phpunit_options']           = [];
+        $GLOBALS['__phpunit_queried_object_id'] = 0;
+        $GLOBALS['__phpunit_is_paged']          = false;
+        $GLOBALS['__phpunit_current_url']       = 'https://www.amnesty.fr/';
+    }
+
+    public function testForeignHostIsRewrittenOntoProduction(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/actualites/mon-article/',
+            amnesty_normalise_canonical_host('https://amnesty.preview.infomaniak.website/actualites/mon-article/')
+        );
+    }
+
+    public function testDotSegmentIsRemovedOnTheProductionHost(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/actualites/',
+            amnesty_normalise_canonical_host('https://www.amnesty.fr/./actualites/')
+        );
+    }
+
+    public function testDotSegmentIsRemovedWhileRewritingTheHost(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/actualites/',
+            amnesty_normalise_canonical_host('https://amnesty.preview.infomaniak.website/./actualites/')
+        );
+    }
+
+    public function testDuplicateSlashesAreCollapsed(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/pays/france/',
+            amnesty_normalise_canonical_host('https://www.amnesty.fr//pays//france/')
+        );
+    }
+
+    public function testParentSegmentIsResolved(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/pays/',
+            amnesty_normalise_canonical_host('https://www.amnesty.fr/pays/france/../')
+        );
+    }
+
+    public function testQueryStringAndTrailingSlashArePreserved(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/petitions/?theme=climat',
+            amnesty_normalise_canonical_host('https://amnesty.preview.infomaniak.website/petitions/?theme=climat')
+        );
+
+        $this->assertSame(
+            'https://www.amnesty.fr/petitions',
+            amnesty_normalise_canonical_host('https://amnesty.preview.infomaniak.website/petitions')
+        );
+    }
+
+    public function testCleanCanonicalIsLeftUnchanged(): void
+    {
+        $url = 'https://www.amnesty.fr/actualites/mon-article/';
+
+        $this->assertSame($url, amnesty_normalise_canonical_host($url));
+    }
+
+    public function testEmptyCanonicalStaysEmpty(): void
+    {
+        $this->assertSame('', amnesty_normalise_canonical_host(''));
+        $this->assertSame('', amnesty_normalise_canonical_host(null));
+    }
+
+    public function testRelativeCanonicalIsLeftUntouched(): void
+    {
+        $this->assertSame('/actualites/', amnesty_normalise_canonical_host('/actualites/'));
+    }
+
+    public function testHomepageCanonicalKeepsItsRootSlash(): void
+    {
+        $this->assertSame(
+            'https://www.amnesty.fr/',
+            amnesty_normalise_canonical_host('https://amnesty.preview.infomaniak.website/')
+        );
+    }
+
+    public function testLocalPortIsPreserved(): void
+    {
+        $GLOBALS['__phpunit_home_url'] = 'http://localhost:8080';
+
+        $this->assertSame(
+            'http://localhost:8080/actualites/',
+            amnesty_normalise_canonical_host('http://localhost:8080/./actualites/')
+        );
+    }
+
+    /**
+     * The regression behind the missing canonicals on /petitions/, /documents/,
+     * /evenements/ and /reperes/: a post type archive has a queried object ID of
+     * 0, which used to match an unset `amnesty_search_page` option.
+     */
+    public function testArchiveKeepsItsCanonicalWhenSearchPageIsUnset(): void
+    {
+        $GLOBALS['__phpunit_queried_object_id'] = 0;
+        $GLOBALS['__phpunit_current_url']       = 'https://www.amnesty.fr/petitions/';
+
+        $this->assertSame(
+            'https://www.amnesty.fr/petitions/',
+            amnesty_wpseo_canonical_filter('https://www.amnesty.fr/petitions/')
+        );
+    }
+
+    public function testSearchPageWithoutFiltersKeepsItsCanonical(): void
+    {
+        $GLOBALS['__phpunit_options']['amnesty_search_page'] = 42;
+        $GLOBALS['__phpunit_queried_object_id']              = 42;
+        $GLOBALS['__phpunit_current_url']                    = 'https://www.amnesty.fr/recherche/';
+
+        $this->assertSame(
+            'https://www.amnesty.fr/recherche/',
+            amnesty_wpseo_canonical_filter('https://www.amnesty.fr/recherche/')
+        );
+    }
+
+    public function testFilteredSearchPageHasNoCanonical(): void
+    {
+        $GLOBALS['__phpunit_options']['amnesty_search_page'] = 42;
+        $GLOBALS['__phpunit_queried_object_id']              = 42;
+        $GLOBALS['__phpunit_current_url']                    = 'https://www.amnesty.fr/recherche/?q=torture';
+
+        $this->assertSame('', amnesty_wpseo_canonical_filter('https://www.amnesty.fr/recherche/'));
+    }
+
+    public function testPagedSearchPageHasNoCanonical(): void
+    {
+        $GLOBALS['__phpunit_options']['amnesty_search_page'] = 42;
+        $GLOBALS['__phpunit_queried_object_id']              = 42;
+        $GLOBALS['__phpunit_is_paged']                       = true;
+
+        $this->assertSame('', amnesty_wpseo_canonical_filter('https://www.amnesty.fr/recherche/'));
+    }
+
+    public function testSchemaGraphIsNormalisedRecursively(): void
+    {
+        $graph = [
+            [
+                '@id' => 'https://amnesty.preview.infomaniak.website/./actualites/#webpage',
+                'url' => 'https://amnesty.preview.infomaniak.website/./actualites/',
+                'name' => 'Actualités',
+            ],
+        ];
+
+        $filtered = amnesty_filter_schema_graph($graph);
+
+        $this->assertSame('https://www.amnesty.fr/actualites/#webpage', $filtered[0]['@id']);
+        $this->assertSame('https://www.amnesty.fr/actualites/', $filtered[0]['url']);
+        $this->assertSame('Actualités', $filtered[0]['name']);
+    }
+
+    public function testEmptyQueryStringYieldsAnEmptyArray(): void
+    {
+        $this->assertSame([], query_string_to_array(''));
+        $this->assertSame([], query_string_to_array('&'));
+    }
+
+    public function testQueryStringIsParsedIntoPairs(): void
+    {
+        $this->assertSame([ 'a' => '1', 'b' => '2' ], query_string_to_array('a=1&b=2'));
+        $this->assertSame([ 'a' => '' ], query_string_to_array('a'));
+        $this->assertSame([ 'redirect' => 'https://www.amnesty.fr/?x=1' ], query_string_to_array('redirect=https://www.amnesty.fr/?x=1'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -208,6 +208,40 @@ if (!function_exists('add_action')) {
     }
 }
 
+if (!function_exists('add_filter')) {
+    $GLOBALS['__phpunit_registered_filters'] = [];
+
+    /**
+     * No-op recorder for add_filter(), mirroring the add_action() stub above:
+     * requiring a file which registers filters at the top level must not fatal,
+     * and tests call the filtered function directly.
+     */
+    function add_filter(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void
+    {
+        $GLOBALS['__phpunit_registered_filters'][$hook][] = $callback;
+    }
+}
+
+if (!function_exists('wp_parse_url')) {
+    /**
+     * Stub for WP's wp_parse_url(), which is a thin wrapper around parse_url().
+     */
+    function wp_parse_url(string $url, int $component = -1): mixed
+    {
+        return parse_url($url, $component);
+    }
+}
+
+if (!function_exists('absint')) {
+    /**
+     * Stub for WP's absint().
+     */
+    function absint(mixed $value): int
+    {
+        return abs((int) $value);
+    }
+}
+
 if (!class_exists('WP_Error')) {
     class WP_Error
     {

--- a/wp-content/themes/humanity-theme/commands/fix-canonical-urls.php
+++ b/wp-content/themes/humanity-theme/commands/fix-canonical-urls.php
@@ -15,9 +15,39 @@ declare(strict_types=1);
  *   wp amnesty fix-canonical-urls
  */
 
+if (! function_exists('amnesty_canonical_host_is_faulty')) {
+    /**
+     * Whether a host is a known preview/staging host that leaked into stored
+     * canonicals and must be rewritten onto production.
+     *
+     * @param string $host the URL host
+     *
+     * @return bool
+     */
+    function amnesty_canonical_host_is_faulty(string $host): bool
+    {
+        // Editing on the Infomaniak preview environment stored its host in
+        // `rel=canonical`. Extend this list if other preview hosts surface.
+        $needles = [ 'infomaniak' ];
+
+        foreach ($needles as $needle) {
+            if (false !== stripos($host, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if (! function_exists('amnesty_canonical_needs_cleanup')) {
     /**
-     * Whether a stored URL differs from its normalised form.
+     * Whether a stored URL should be rewritten in the database.
+     *
+     * Unlike the runtime `wpseo_canonical` filter, this migration is
+     * destructive, so it stays conservative: only known faulty hosts and dirty
+     * paths on the production host are touched. An intentional external
+     * canonical (e.g. www.amnesty.org) keeps its host untouched.
      *
      * @param string $url the stored URL
      *
@@ -29,6 +59,27 @@ if (! function_exists('amnesty_canonical_needs_cleanup')) {
             return false;
         }
 
+        $host = wp_parse_url($url, PHP_URL_HOST);
+
+        // Relative URLs carry no host and are left untouched by the normaliser.
+        if (! $host) {
+            return false;
+        }
+
+        // A known preview/staging host is always forced back to production.
+        if (amnesty_canonical_host_is_faulty((string) $host)) {
+            return true;
+        }
+
+        $home_host = wp_parse_url(home_url(), PHP_URL_HOST);
+
+        // Any other foreign host may be a deliberate external canonical -
+        // never overwrite it during a DB migration.
+        if ($home_host && $host !== $home_host) {
+            return false;
+        }
+
+        // Same host: clean up only when the path/query normalisation changes it.
         return amnesty_normalise_canonical_host($url) !== $url;
     }
 }
@@ -139,6 +190,12 @@ if (! function_exists('amnesty_fix_canonical_indexables')) {
 
             if (! $update) {
                 continue;
+            }
+
+            // Yoast indexes lookups by permalink_hash (strlen:md5 of the
+            // permalink). Recompute it or those lookups miss the fixed rows.
+            if (isset($update['permalink'])) {
+                $update['permalink_hash'] = strlen($update['permalink']) . ':' . md5($update['permalink']);
             }
 
             if (! $dry_run) {

--- a/wp-content/themes/humanity-theme/commands/fix-canonical-urls.php
+++ b/wp-content/themes/humanity-theme/commands/fix-canonical-urls.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * One-shot cleanup for canonical URLs stored with the wrong host or a dirty path.
+ *
+ * The `wpseo_canonical` / `wpseo_opengraph_url` / `wpseo_schema_graph` filters in
+ * includes/seo/canonical.php fix the rendered HTML, but the bad values remain in
+ * the database and leak through anything that reads them directly (Yoast
+ * sitemaps, REST, exports). This command rewrites them in place.
+ *
+ * Usage:
+ *   wp amnesty fix-canonical-urls --dry-run
+ *   wp amnesty fix-canonical-urls
+ */
+
+if (! function_exists('amnesty_canonical_needs_cleanup')) {
+    /**
+     * Whether a stored URL differs from its normalised form.
+     *
+     * @param string $url the stored URL
+     *
+     * @return bool
+     */
+    function amnesty_canonical_needs_cleanup(string $url): bool
+    {
+        if ('' === trim($url)) {
+            return false;
+        }
+
+        return amnesty_normalise_canonical_host($url) !== $url;
+    }
+}
+
+if (! function_exists('amnesty_fix_canonical_postmeta')) {
+    /**
+     * Clean the `_yoast_wpseo_canonical` post meta.
+     *
+     * A meta whose normalised value equals the post permalink is removed
+     * altogether: Yoast then falls back to the implicit self-canonical.
+     *
+     * @global wpdb $wpdb
+     *
+     * @param bool $dry_run whether to report without writing
+     *
+     * @return array{inspected:int,updated:int,deleted:int}
+     */
+    function amnesty_fix_canonical_postmeta(bool $dry_run): array
+    {
+        global $wpdb;
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value != ''",
+                '_yoast_wpseo_canonical'
+            )
+        );
+
+        $stats = [ 'inspected' => count($rows), 'updated' => 0, 'deleted' => 0 ];
+
+        foreach ($rows as $row) {
+            $stored = (string) $row->meta_value;
+
+            if (! amnesty_canonical_needs_cleanup($stored)) {
+                continue;
+            }
+
+            $post_id   = (int) $row->post_id;
+            $clean     = amnesty_normalise_canonical_host($stored);
+            $permalink = get_permalink($post_id);
+
+            if ($permalink && amnesty_normalise_canonical_host($permalink) === $clean) {
+                WP_CLI::log(sprintf('post %d: drop meta (self-canonical) - was %s', $post_id, $stored));
+
+                if (! $dry_run) {
+                    delete_post_meta($post_id, '_yoast_wpseo_canonical');
+                }
+
+                $stats['deleted']++;
+
+                continue;
+            }
+
+            WP_CLI::log(sprintf('post %d: %s -> %s', $post_id, $stored, $clean));
+
+            if (! $dry_run) {
+                update_post_meta($post_id, '_yoast_wpseo_canonical', $clean);
+            }
+
+            $stats['updated']++;
+        }
+
+        return $stats;
+    }
+}
+
+if (! function_exists('amnesty_fix_canonical_indexables')) {
+    /**
+     * Clean the `canonical` and `permalink` columns of the Yoast indexable table.
+     *
+     * @global wpdb $wpdb
+     *
+     * @param bool $dry_run whether to report without writing
+     *
+     * @return array{inspected:int,updated:int}
+     */
+    function amnesty_fix_canonical_indexables(bool $dry_run): array
+    {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'yoast_indexable';
+
+        if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) !== $table) {
+            WP_CLI::warning(sprintf('Table %s introuvable, étape ignorée.', $table));
+
+            return [ 'inspected' => 0, 'updated' => 0 ];
+        }
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $rows = $wpdb->get_results("SELECT id, permalink, canonical FROM {$table}");
+
+        $stats = [ 'inspected' => count($rows), 'updated' => 0 ];
+
+        foreach ($rows as $row) {
+            $update = [];
+
+            foreach ([ 'permalink', 'canonical' ] as $column) {
+                $stored = (string) ($row->{$column} ?? '');
+
+                if (! amnesty_canonical_needs_cleanup($stored)) {
+                    continue;
+                }
+
+                $update[$column] = amnesty_normalise_canonical_host($stored);
+
+                WP_CLI::log(sprintf('indexable %d [%s]: %s -> %s', $row->id, $column, $stored, $update[$column]));
+            }
+
+            if (! $update) {
+                continue;
+            }
+
+            if (! $dry_run) {
+                $wpdb->update($table, $update, [ 'id' => (int) $row->id ]);
+            }
+
+            $stats['updated']++;
+        }
+
+        return $stats;
+    }
+}
+
+if (! function_exists('amnesty_fix_canonical_urls_command')) {
+    /**
+     * WP-CLI entrypoint.
+     *
+     * @param array $args       positional arguments (unused)
+     * @param array $assoc_args associative arguments
+     *
+     * @return void
+     */
+    function amnesty_fix_canonical_urls_command($args, $assoc_args): void
+    {
+        $dry_run = (bool) ($assoc_args['dry-run'] ?? false);
+
+        if ($dry_run) {
+            WP_CLI::log('Mode simulation : aucune écriture en base.');
+        }
+
+        $meta       = amnesty_fix_canonical_postmeta($dry_run);
+        $indexables = amnesty_fix_canonical_indexables($dry_run);
+
+        WP_CLI::success(sprintf(
+            '_yoast_wpseo_canonical : %d inspectés, %d corrigés, %d supprimés.',
+            $meta['inspected'],
+            $meta['updated'],
+            $meta['deleted']
+        ));
+
+        WP_CLI::success(sprintf(
+            'yoast_indexable : %d inspectés, %d corrigés.',
+            $indexables['inspected'],
+            $indexables['updated']
+        ));
+
+        if ($dry_run) {
+            WP_CLI::log('Relancer sans --dry-run pour appliquer.');
+
+            return;
+        }
+
+        WP_CLI::log('Pensez à purger le cache : wp-cli cloudflare cache_purge');
+    }
+}
+
+WP_CLI::add_command('amnesty fix-canonical-urls', 'amnesty_fix_canonical_urls_command');

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -599,6 +599,7 @@ function turnstile_friendly_error(string $error): string
 if (defined('WP_CLI') && WP_CLI) {
     require_once __DIR__ . '/commands/duplicate-country-pages.php';
     require_once __DIR__ . '/commands/upgrade-country-pages.php';
+    require_once __DIR__ . '/commands/fix-canonical-urls.php';
 }
 
 add_filter('render_block', function ($block_content, $block) {

--- a/wp-content/themes/humanity-theme/includes/helpers/string-manipulation.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/string-manipulation.php
@@ -217,13 +217,22 @@ if (! function_exists('query_string_to_array')) {
      */
     function query_string_to_array(string $query): array
     {
-        $query = rawurldecode((string) $query);
-        $query = explode('&', $query);
-        $query = array_map(fn (string $arg) => explode('=', $arg), $query);
-        $query = array_map(fn (array $arg) => [ $arg[0] => $arg[1] ?? '' ], $query);
-        $query = array_merge(...$query);
+        $query = trim(rawurldecode($query), " \t\n\r\0\x0B?&");
 
-        return (array) $query;
+        if ('' === $query) {
+            return [];
+        }
+
+        $pairs = array_filter(explode('&', $query), fn (string $arg) => '' !== $arg);
+
+        if (! $pairs) {
+            return [];
+        }
+
+        $pairs = array_map(fn (string $arg) => explode('=', $arg, 2), $pairs);
+        $pairs = array_map(fn (array $arg) => [ $arg[0] => $arg[1] ?? '' ], $pairs);
+
+        return array_merge(...$pairs);
     }
 }
 

--- a/wp-content/themes/humanity-theme/includes/seo/canonical.php
+++ b/wp-content/themes/humanity-theme/includes/seo/canonical.php
@@ -2,6 +2,50 @@
 
 declare(strict_types=1);
 
+if (! function_exists('amnesty_normalise_url_path')) {
+    /**
+     * Resolve dot segments and duplicate slashes out of a URL path.
+     *
+     * Some stored canonicals carry a `/./` segment, which Google treats as a
+     * distinct URL from the clean one. Rebuild the path from its meaningful
+     * segments, keeping the trailing slash when there was one.
+     *
+     * @param string $path The URL path to normalise.
+     *
+     * @return string The normalised, absolute path.
+     */
+    function amnesty_normalise_url_path(string $path): string
+    {
+        if ('' === $path) {
+            return '/';
+        }
+
+        $segments = [];
+
+        foreach (explode('/', $path) as $segment) {
+            if ('' === $segment || '.' === $segment) {
+                continue;
+            }
+
+            if ('..' === $segment) {
+                array_pop($segments);
+
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        $normalised = '/' . implode('/', $segments);
+
+        if ('/' !== $normalised && str_ends_with($path, '/')) {
+            $normalised .= '/';
+        }
+
+        return $normalised;
+    }
+}
+
 if (! function_exists('amnesty_normalise_canonical_host')) {
     /**
      * Force a canonical URL onto the production host.
@@ -10,6 +54,10 @@ if (! function_exists('amnesty_normalise_canonical_host')) {
      * environment, leaving the wrong (and inaccessible) host in `rel=canonical`.
      * This rewrites the scheme + host to the official site URL while keeping the
      * path and query intact, so pages stay self-canonical on www.amnesty.fr.
+     *
+     * The path is normalised in every case, including when the host is already
+     * the right one: a canonical such as `https://www.amnesty.fr/./actualites/`
+     * has a valid host but still points at a URL Google sees as a duplicate.
      *
      * @param string|null $canonical The canonical URL to normalise.
      *
@@ -21,17 +69,29 @@ if (! function_exists('amnesty_normalise_canonical_host')) {
             return '';
         }
 
-        $home_host      = wp_parse_url(home_url(), PHP_URL_HOST);
         $canonical_host = wp_parse_url($canonical, PHP_URL_HOST);
 
-        if (! $home_host || ! $canonical_host || $canonical_host === $home_host) {
+        // Relative URLs carry no host to rewrite - leave them untouched.
+        if (! $canonical_host) {
             return $canonical;
         }
 
-        $path  = (string) (wp_parse_url($canonical, PHP_URL_PATH) ?: '/');
-        $query = wp_parse_url($canonical, PHP_URL_QUERY);
+        $home_host = wp_parse_url(home_url(), PHP_URL_HOST);
+        $path      = amnesty_normalise_url_path((string) (wp_parse_url($canonical, PHP_URL_PATH) ?: '/'));
+        $query     = wp_parse_url($canonical, PHP_URL_QUERY);
+        $fragment  = wp_parse_url($canonical, PHP_URL_FRAGMENT);
 
-        return home_url($path . ($query ? '?' . $query : ''));
+        // Yoast schema @id nodes are URLs with a fragment (#webpage, #organization).
+        $suffix = $path . ($query ? '?' . $query : '') . ($fragment ? '#' . $fragment : '');
+
+        if ($home_host && $canonical_host !== $home_host) {
+            return home_url($suffix);
+        }
+
+        $scheme = wp_parse_url($canonical, PHP_URL_SCHEME) ?: 'https';
+        $port   = wp_parse_url($canonical, PHP_URL_PORT);
+
+        return sprintf('%s://%s%s%s', $scheme, $canonical_host, $port ? ':' . $port : '', $suffix);
     }
 }
 
@@ -85,35 +145,13 @@ if (! function_exists('amnesty_filter_schema_graph')) {
 
 add_filter('wpseo_schema_graph', 'amnesty_filter_schema_graph');
 
-if (! function_exists('amnesty_render_canonical')) {
-    /**
-     * Render the canonical href on posts
-     *
-     * @return void
-     */
-    function amnesty_render_canonical(): void
-    {
-        if (is_admin() || ! is_single()) {
-            return;
-        }
-
-        $canonical = get_post_meta(get_the_ID(), '_yoast_wpseo_canonical', true);
-
-        if (! $canonical) {
-            return;
-        }
-
-        $canonical = amnesty_normalise_canonical_host((string) $canonical);
-
-        printf('<link rel="canonical" href="%s">', esc_url($canonical));
-    }
-}
-
-add_action('wp_head', 'amnesty_render_canonical');
-
 if (! function_exists('amnesty_wpseo_canonical_filter')) {
     /**
      * Remove erroneous canonicals from search results/filters
+     *
+     * Only the search page itself may end up without a canonical: everything
+     * else - including post type archives, whose queried object ID is 0 like an
+     * unset `amnesty_search_page` option - stays self-canonical.
      *
      * @package Amnesty
      *
@@ -123,7 +161,9 @@ if (! function_exists('amnesty_wpseo_canonical_filter')) {
      */
     function amnesty_wpseo_canonical_filter(?string $canonical = ''): string
     {
-        if (get_queried_object_id() !== absint(get_option('amnesty_search_page'))) {
+        $search_page = absint(get_option('amnesty_search_page'));
+
+        if (0 === $search_page || get_queried_object_id() !== $search_page) {
             return amnesty_normalise_canonical_host($canonical);
         }
 


### PR DESCRIPTION
## Contexte

[MAINT-231](https://linear.app/les-tilleuls/issue/MAINT-231) a été livré une première fois (PR #991, présent sur `main` et `prod`) puis repassé **In Progress** le 10/07 par Coline : « test is KO in prod ».

Un ré-audit de la production confirme que l'objectif initial est atteint mais que deux défauts subsistent sur les pages d'archive :

| Constat | Résultat |
|---|---|
| 70 pages de contenu crawlées (sitemap + navigation) | canonical correct, **0 occurrence `infomaniak`** ✅ |
| `https://www.amnesty.fr/actualites/` | `<link rel="canonical" href="https://www.amnesty.fr/./actualites/">` (idem `og:url`) ❌ |
| `/petitions/`, `/documents/`, `/evenements/`, `/reperes/` | **aucune balise canonical** ❌ |

## Causes racines

**Canonical vide sur les archives de CPT** — `query_string_to_array('')` renvoyait `['' => '']` et non `[]` (`explode('&', '')` donne `['']`). Le test `if (! empty($query_string)) { return ''; }` d'`amnesty_wpseo_canonical_filter()` était donc toujours vrai. Cette branche est atteinte dès que `get_queried_object_id() === absint(get_option('amnesty_search_page'))` — or une archive de CPT a un queried object ID de `0`, tout comme une option non définie.

**Segment `/./` conservé** — `amnesty_normalise_canonical_host()` sortait en avance quand l'hôte était déjà celui de production, donc un chemin sale n'était jamais nettoyé.

## Modifications

- `includes/helpers/string-manipulation.php` — `query_string_to_array()` retourne `[]` sur une chaîne vide, ignore les fragments vides, et ne tronque plus une valeur contenant un `=`.
- `includes/seo/canonical.php`
  - nouvelle `amnesty_normalise_url_path()` : résout les segments `.` et `..`, collapse les `//`, préserve le slash final ;
  - `amnesty_normalise_canonical_host()` normalise le chemin quel que soit l'hôte, en conservant le port et le **fragment** (les nœuds `@id` du schema Yoast en dépendent) ; une URL relative reste intacte ;
  - `amnesty_wpseo_canonical_filter()` ne vide plus le canonical quand `amnesty_search_page` n'est pas définie ;
  - suppression d'`amnesty_render_canonical()` et de son `add_action('wp_head')` — doublon avec la balise de Yoast.
- `commands/fix-canonical-urls.php` (nouveau) — `wp amnesty fix-canonical-urls [--dry-run]` nettoie les valeurs **stockées** : postmeta `_yoast_wpseo_canonical` (le meta est supprimé s'il redevient égal au permalien) et colonnes `canonical` / `permalink` de `wp_yoast_indexable`. Les filtres ne corrigent que le rendu HTML ; sans ça les mauvaises valeurs continuent de fuiter par tout consommateur non filtré.
- `tests/Seo/CanonicalTest.php` + testsuite `Seo` ; stubs génériques `add_filter` / `wp_parse_url` / `absint` ajoutés à `tests/bootstrap.php`.

## Tests

- `./vendor/bin/phpunit --testsuite Seo` → **OK, 18 tests, 25 assertions**.
- `./vendor/bin/php-cs-fixer fix --dry-run` → clean.
- Le reste de la suite est inchangé par cette PR.

## Utilisation de la commande `fix-canonical-urls`

Nettoie les canonicals **stockés en base** (les filtres runtime ne corrigent que le rendu HTML).

```bash
# 1. Simulation : liste ce qui serait modifié, aucune écriture.
wp amnesty fix-canonical-urls --dry-run

# 2. Après relecture de la sortie, application réelle.
wp amnesty fix-canonical-urls

# 3. Purge du cache.
wp-cli cloudflare cache_purge
```

Ce qui est traité :

- **postmeta `_yoast_wpseo_canonical`** — réécrit sur l'hôte de prod ; le meta est **supprimé** s'il redevient égal au permalien (Yoast retombe alors sur le self-canonical implicite).
- **colonnes `canonical` / `permalink` de `wp_yoast_indexable`** — normalisées ; `permalink_hash` est recalculé en même temps que `permalink` pour ne pas casser les lookups indexés de Yoast.

Garde-fous (commande destructive) :

- Seuls les **hosts de preview connus** (Infomaniak) et les **paths sales** (`/./`, `//`, `..`) sur l'hôte de prod sont corrigés.
- Un canonical **externe volontaire** (ex. `www.amnesty.org`) est **préservé**, jamais réécrit vers `www.amnesty.fr`.
- Idempotente : relançable sans effet une fois la base propre. Toujours lancer `--dry-run` d'abord.

## Recette

1. Vérifier qu'il y a **exactement une** balise canonical, absolue, sans `/./` ni `//`, sur : `/`, `/actualites/`, `/petitions/`, `/documents/`, `/evenements/`, `/reperes/`, `/pays/france`, un article, une page paginée, la page de recherche avec et sans filtres.
2. Lancer `wp amnesty fix-canonical-urls --dry-run` puis, après relecture de la sortie, sans le flag.
3. Purger le cache Cloudflare (`wp-cli cloudflare cache_purge`).

Thibaut ayant noté le 11/06 que le problème n'est pas reproductible en preprod, la validation finale se fera directement en production après MEP.

## Hors périmètre

Le commentaire de Romain du 30/07 (URLs absentes du sitemap Jetpack + URLs orphelines) fera l'objet d'un ticket séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)