### PR TITLE
fix(sentry): null sf_member (MAINT-298)

### DIFF
--- a/wp-content/themes/humanity-theme/page-mes-informations-personnelles.php
+++ b/wp-content/themes/humanity-theme/page-mes-informations-personnelles.php
@@ -59,7 +59,8 @@ $countries = [
 $actifMandate = get_active_sepa_mandate($SEPA_mandates->records);
 $next_payement = '';
 
-$has_valid_mandate = $sf_member->hasMandatActif && null !== $actifMandate;
+$has_member_data = null !== $sf_member;
+$has_valid_mandate = $has_member_data && $sf_member->hasMandatActif && null !== $actifMandate;
 
 if ($has_valid_mandate) {
     $day_of_payment = date('d', strtotime($actifMandate->Date_paiement_Avenir__c));
@@ -68,7 +69,7 @@ if ($has_valid_mandate) {
     $next_payement = date_format(date_create($actifMandate->Date_paiement_Avenir__c), 'd/m/Y');
 }
 
-$user_status = aif_get_user_status($sf_member);
+$user_status = $has_member_data ? aif_get_user_status($sf_member) : '';
 
 function checkKeys($requiredFields, $array_to_check)
 {


### PR DESCRIPTION
**N.B** : des problèmes similaires ont déjà été levés précédemment. Il faudrait peut-être investiguer + en profondeur dans un ticket dédié pourquoi `get_salesforce_member_data($email)` renvoie `null` (email du currentUser différent de celui renseigné dans le contact Salesforce ? problème au niveau de la méthode get_salesforce_data_donor_space ? 
Piste de claude => 

> get_salesforce_data_donor_space() retourne implicitement null si  wp_remote_get() renvoie un WP_Error (branche if (is_wp_error($response)) sans return). json_decode() peut aussi renvoyer null sur un corps vide/invalide.)