### PR TITLE
fix: ajuste les couleurs du bandeau d’alerte

### DIFF
--- a/private/src/styles/layout/_alert-banner.scss
+++ b/private/src/styles/layout/_alert-banner.scss
@@ -19,6 +19,7 @@
     max-width: $container-md;
     margin: 0 auto;
     width: 100%;
+    color: var(--wp--preset--color--white);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -47,9 +48,11 @@
       .alert-body-text {
         display: flex;
         flex-direction: column;
+        color: inherit;
 
         > .title {
           margin-bottom: 10px;
+          color: inherit;
           line-height: 100%;
           font-size: 32px;
           font-weight: bold;
@@ -59,10 +62,15 @@
         }
 
         > .description {
+          color: inherit;
           font-size: 18px;
           letter-spacing: 0;
           font-family: var(--wp--preset--font-family--primary);
           text-transform: none;
+
+          * {
+            color: inherit;
+          }
         }
       }
     }
@@ -70,16 +78,16 @@
     > .cta {
       padding: 6px 30px;
       background: transparent;
-      color: var(--wp--preset--color--black);
-      border: 2px solid var(--wp--preset--color--black);
+      color: inherit;
+      border: 2px solid var(--wp--preset--color--white);
       font-weight: bold;
       text-transform: uppercase;
       text-decoration: none;
-      transition: all ease 0.4s;
+      transition: all ease 0.3s;
 
       &:hover {
-        background: rgba(0, 0, 0, 0.2);
-        color: var(--wp--preset--color--grey-darkest);
+        background-color: var(--wp--preset--color--light-pink);
+        color: inherit;
       }
     }
   }


### PR DESCRIPTION
## Contexte

Suite aux modifications du ticket `feat/MAINT-288-style-bandeau-alerte`, les contenus texte du bandeau d’alerte devaient être affichés en blanc, et le CTA devait reprendre le comportement au hover du bouton de don desktop.

## Modifications

- Passage en blanc du titre, de la description et des contenus texte imbriqués du bandeau d’alerte.
- Passage du CTA en texte blanc avec bordure blanche.
- Alignement du hover du CTA sur le bouton `.donate-button-desktop` avec le fond `light-pink`.

<img width="918" height="622" alt="Capture d’écran 2026-08-05 à 09 41 14" src="https://github.com/user-attachments/assets/de43c109-13f8-47a9-8e74-c1de3129a564" />


## Tests

- `yarn build:dev`
- `yarn lint:styles`