### PR TITLE
fix: passer le bouton de fermeture de la bannière d'alerte en blanc

### DIFF
--- a/private/src/styles/layout/_alert-banner.scss
+++ b/private/src/styles/layout/_alert-banner.scss
@@ -11,8 +11,12 @@
     position: absolute;
     top: 15px;
     right: 15px;
-    color: var(--wp--preset--color--black);
+    color: var(--wp--preset--color--white);
     cursor: pointer;
+
+    path {
+      stroke: currentColor;
+    }
   }
 
   > .alert-banner-body {


### PR DESCRIPTION
retour recette : le bouton de fermeture de la bannière d'alerte était aussi à passer en blanc