### PR TITLE
feat: MAINT-294 - ajoute la possibilité de changer l'ordre des fichiers 

### DIFF
--- a/private/src/scripts/editor/blocks/download-go-further/EditComponent.jsx
+++ b/private/src/scripts/editor/blocks/download-go-further/EditComponent.jsx
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 const { useSelect } = wp.data;
 const { useBlockProps, InspectorControls, MediaUpload, MediaUploadCheck } = wp.blockEditor;
-const { PanelBody, Button, TextControl } = wp.components;
+const { PanelBody, Button, ButtonGroup, TextControl } = wp.components;
 
 const EditComponent = ({ attributes, setAttributes }) => {
   const { title, fileIds = [] } = attributes;
@@ -110,6 +110,19 @@ const EditComponent = ({ attributes, setAttributes }) => {
     setAttributes({ fileIds: newIds });
   };
 
+  const moveFile = (index, direction) => {
+    const nextIndex = index + direction;
+
+    if (nextIndex < 0 || nextIndex >= fileIds.length) {
+      return;
+    }
+
+    const newIds = [...fileIds];
+    [newIds[index], newIds[nextIndex]] = [newIds[nextIndex], newIds[index]];
+
+    setAttributes({ fileIds: newIds });
+  };
+
   const formatFileSize = (file) => {
     const size = file?.media_details?.filesize || 0;
     return `${(size / 1024).toFixed(2)} kb`;
@@ -136,18 +149,34 @@ const EditComponent = ({ attributes, setAttributes }) => {
               )}
             />
           </MediaUploadCheck>
-          <ul>
+          <ul className="download-go-further-files-control">
             {files.map(
-              (file) =>
+              (file, index) =>
                 file && (
-                  <li key={file.id}>
-                    <span>
+                  <li key={file.id} className="download-go-further-files-control__item">
+                    <span className="download-go-further-files-control__label">
                       {file.title?.rendered || file.slug} (
                       {getHumanReadableFileType(file.mime_type)}, {formatFileSize(file)})
                     </span>
-                    <Button onClick={() => removeFile(file.id)} isSecondary>
-                      {__('Supprimer', 'amnesty')}
-                    </Button>
+                    <ButtonGroup className="download-go-further-files-control__actions">
+                      <Button
+                        icon="arrow-up-alt2"
+                        label={__('Monter le fichier', 'amnesty')}
+                        onClick={() => moveFile(index, -1)}
+                        disabled={index === 0}
+                        variant="secondary"
+                      />
+                      <Button
+                        icon="arrow-down-alt2"
+                        label={__('Descendre le fichier', 'amnesty')}
+                        onClick={() => moveFile(index, 1)}
+                        disabled={index === fileIds.length - 1}
+                        variant="secondary"
+                      />
+                      <Button onClick={() => removeFile(file.id)} isSecondary>
+                        {__('Supprimer', 'amnesty')}
+                      </Button>
+                    </ButtonGroup>
                   </li>
                 ),
             )}

--- a/private/src/styles/blocks/download-go-further/_main.scss
+++ b/private/src/styles/blocks/download-go-further/_main.scss
@@ -115,3 +115,30 @@
     }
   }
 }
+
+.download-go-further-files-control {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 16px 0 0;
+  padding: 0;
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border: 1px solid #ddd;
+    list-style: none;
+  }
+
+  &__label {
+    overflow-wrap: anywhere;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+}


### PR DESCRIPTION
## Contexte

Cette PR met à jour le bloc `amnesty-core/download-go-further`, utilisé pour afficher une liste de documents téléchargeables, en ajoutant la possibilité de modifier l'ordre d'affichage des documents. 

## Changements

- Ajuste le rendu du bloc Documents à télécharger.
- Conserve la configuration Gutenberg basée sur un titre et une liste d’IDs de fichiers.

<img width="1217" height="628" alt="Capture d’écran 2026-08-05 à 16 40 24" src="https://github.com/user-attachments/assets/fdbd9eac-ab14-4416-9054-ba1046ded737" />

## Tests

- Vérifier que le bloc “Documents à télécharger” peut être ajouté dans Gutenberg.
- Vérifier qu’un fichier média peut être sélectionné depuis la bibliothèque.
- Vérifier que le rendu frontend affiche le titre, le nom du fichier, son type, sa taille et le bouton “Télécharger”.