### PR TITLE
feat(analytics): ajout de tracking sur la connexion mon espace

### DIFF
--- a/tests/DonorSpace/MySpaceLoginTrackingTest.php
+++ b/tests/DonorSpace/MySpaceLoginTrackingTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!function_exists('is_admin')) {
+    function is_admin(): bool
+    {
+        return $GLOBALS['__phpunit_is_admin'] ?? false;
+    }
+}
+
+if (!function_exists('is_page')) {
+    function is_page(int|string|array|null $page = null): bool
+    {
+        return $GLOBALS['__phpunit_is_page'] ?? false;
+    }
+}
+
+if (!function_exists('is_preview')) {
+    function is_preview(): bool
+    {
+        return $GLOBALS['__phpunit_is_preview'] ?? false;
+    }
+}
+
+if (!function_exists('get_queried_object')) {
+    function get_queried_object(): ?object
+    {
+        return $GLOBALS['__phpunit_queried_object'] ?? null;
+    }
+}
+
+if (!function_exists('get_page_by_path')) {
+    function get_page_by_path(string $path): ?object
+    {
+        return $GLOBALS['__phpunit_pages_by_path'][$path] ?? null;
+    }
+}
+
+if (!function_exists('get_post_ancestors')) {
+    function get_post_ancestors(int|object $post): array
+    {
+        $post_id = is_object($post) ? $post->ID : $post;
+
+        return $GLOBALS['__phpunit_post_ancestors'][$post_id] ?? [];
+    }
+}
+
+require_once dirname(__DIR__, 2) . '/wp-content/themes/humanity-theme/includes/theme-setup/analytics/my-space-login.php';
+
+final class MySpaceLoginTrackingTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['__phpunit_current_user_id'] = 42;
+        $GLOBALS['__phpunit_is_admin'] = false;
+        $GLOBALS['__phpunit_is_page'] = true;
+        $GLOBALS['__phpunit_is_preview'] = false;
+        $GLOBALS['__phpunit_pages_by_path'] = [
+            'mon-espace' => (object) ['ID' => 10],
+        ];
+        $GLOBALS['__phpunit_queried_object'] = (object) ['ID' => 10];
+        $GLOBALS['__phpunit_post_ancestors'] = [];
+    }
+
+    public function testOutputsTrackingOnMySpaceHomepageForLoggedInUser(): void
+    {
+        $output = $this->renderTrackingScript();
+
+        self::assertTrue(aif_should_output_my_space_login_tracking());
+        self::assertStringContainsString('aif_mon_espace_login_tracked', $output);
+        self::assertStringContainsString("event: 'login'", $output);
+        self::assertStringContainsString("method: 'mon_espace'", $output);
+        self::assertStringContainsString("'max-age=1800'", $output);
+        self::assertStringContainsString("'SameSite=Lax'", $output);
+        self::assertStringContainsString("cookieAttributes.push('Secure')", $output);
+        self::assertStringContainsString("document.cookie = cookieAttributes.join('; ')", $output);
+        self::assertStringContainsString('if (cookieExists)', $output);
+        self::assertStringContainsString('window.dataLayer = window.dataLayer || []', $output);
+    }
+
+    public function testOutputsTrackingOnMySpaceChildPageForLoggedInUser(): void
+    {
+        $GLOBALS['__phpunit_queried_object'] = (object) ['ID' => 20];
+        $GLOBALS['__phpunit_post_ancestors'] = [
+            20 => [10],
+        ];
+
+        $output = $this->renderTrackingScript();
+
+        self::assertTrue(aif_should_output_my_space_login_tracking());
+        self::assertStringContainsString("method: 'mon_espace'", $output);
+    }
+
+    public function testDoesNotOutputTrackingForLoggedOutUser(): void
+    {
+        $GLOBALS['__phpunit_current_user_id'] = 0;
+
+        self::assertFalse(aif_should_output_my_space_login_tracking());
+        self::assertSame('', $this->renderTrackingScript());
+    }
+
+    public function testDoesNotOutputTrackingOutsideMySpace(): void
+    {
+        $GLOBALS['__phpunit_queried_object'] = (object) ['ID' => 30];
+        $GLOBALS['__phpunit_post_ancestors'] = [
+            30 => [],
+        ];
+
+        self::assertFalse(aif_should_output_my_space_login_tracking());
+        self::assertSame('', $this->renderTrackingScript());
+    }
+
+    public function testDoesNotOutputTrackingInAdmin(): void
+    {
+        $GLOBALS['__phpunit_is_admin'] = true;
+
+        self::assertFalse(aif_should_output_my_space_login_tracking());
+        self::assertSame('', $this->renderTrackingScript());
+    }
+
+    public function testDoesNotOutputTrackingOnPreview(): void
+    {
+        $GLOBALS['__phpunit_is_preview'] = true;
+
+        self::assertFalse(aif_should_output_my_space_login_tracking());
+        self::assertSame('', $this->renderTrackingScript());
+    }
+
+    private function renderTrackingScript(): string
+    {
+        ob_start();
+        aif_output_my_space_login_tracking();
+
+        return (string) ob_get_clean();
+    }
+}

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -189,6 +189,7 @@ require_once realpath(__DIR__ . '/includes/theme-setup/navigation.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/scripts-and-styles.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/analytics/google-tag-manager.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/analytics/google-analytics.php');
+require_once realpath(__DIR__ . '/includes/theme-setup/analytics/my-space-login.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/analytics/hotjar.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/analytics/vwo.php');
 require_once realpath(__DIR__ . '/includes/theme-setup/analytics/meta-tags.php');

--- a/wp-content/themes/humanity-theme/includes/theme-setup/analytics/my-space-login.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/analytics/my-space-login.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+if (! function_exists('aif_is_my_space_page_for_tracking')) {
+    function aif_is_my_space_page_for_tracking(): bool
+    {
+        if (! is_page() || is_preview()) {
+            return false;
+        }
+
+        $current_page = get_queried_object();
+        $parent_page = get_page_by_path('mon-espace');
+
+        if (
+            ! $current_page ||
+            ! isset($current_page->ID) ||
+            ! $parent_page ||
+            ! isset($parent_page->ID)
+        ) {
+            return false;
+        }
+
+        if ((int) $current_page->ID === (int) $parent_page->ID) {
+            return true;
+        }
+
+        return in_array((int) $parent_page->ID, get_post_ancestors((int) $current_page->ID), true);
+    }
+}
+
+if (! function_exists('aif_should_output_my_space_login_tracking')) {
+    function aif_should_output_my_space_login_tracking(): bool
+    {
+        if (is_admin() || ! is_user_logged_in()) {
+            return false;
+        }
+
+        return aif_is_my_space_page_for_tracking();
+    }
+}
+
+if (! function_exists('aif_output_my_space_login_tracking')) {
+    function aif_output_my_space_login_tracking(): void
+    {
+        if (! aif_should_output_my_space_login_tracking()) {
+            return;
+        }
+        ?>
+		<script type="text/javascript">
+			(function () {
+				const cookieName = 'aif_mon_espace_login_tracked';
+				const cookieExists = document.cookie
+					.split(';')
+					.some((cookie) => cookie.trim().startsWith(cookieName + '='));
+				const cookieAttributes = [
+					cookieName + '=1',
+					'max-age=1800',
+					'path=/',
+					'SameSite=Lax',
+				];
+
+				if (window.location.protocol === 'https:') {
+					cookieAttributes.push('Secure');
+				}
+
+				document.cookie = cookieAttributes.join('; ');
+
+				if (cookieExists) {
+					return;
+				}
+
+				window.dataLayer = window.dataLayer || [];
+				window.dataLayer.push({
+					event: 'login',
+					method: 'mon_espace',
+				});
+			})();
+		</script>
+		<?php
+    }
+}
+
+add_action('wp_footer', 'aif_output_my_space_login_tracking');


### PR DESCRIPTION
## Description

Ajout du tracking GTM/GA4 pour les connexions réussies à Mon Espace.
L’événement est déclenché uniquement lorsqu’un utilisateur authentifié accède à /mon-espace ou à une page enfant de Mon Espace. Il n’est donc pas envoyé au clic sur le CTA “Se connecter”, ni en cas d’échec de connexion.

Événement envoyé dans le dataLayer :
`{ event: 'login', method: 'mon_espace' }`

Un cookie aif_mon_espace_login_tracked limite le comptage à une seule connexion par session analytics. Sa durée est de 30 minutes, ce qui correspond à la durée standard d’une session GA4 : tant que l’utilisateur reste actif dans cette fenêtre, les pages vues suivantes dans Mon Espace ne renvoient pas l’événement.

## Tests
composer run test:donor-space
composer run cs
php -d memory_limit=1G vendor/bin/phpstan analyze --no-progress