### PR TITLE
fix(donor-space): fiabilise les appels Salesforce (MAINT-302)

### DIFF
--- a/tests/DonorSpace/SalesforceAuthenticationTest.php
+++ b/tests/DonorSpace/SalesforceAuthenticationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class SalesforceAuthenticationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('AIF_SALESFORCE_URL')) {
+            define('AIF_SALESFORCE_URL', 'https://salesforce.example.test/');
+            define('AIF_SALESFORCE_CLIENT_ID', 'client-id');
+            define('AIF_SALESFORCE_SECRET', 'client-secret');
+        }
+
+        if (!function_exists('wp_remote_post')) {
+            function wp_remote_post(string $url, array $args = []): mixed
+            {
+                $GLOBALS['__phpunit_wp_remote_calls'][] = ['method' => 'POST', 'url' => $url, 'args' => $args];
+
+                return $GLOBALS['__phpunit_wp_remote_response'];
+            }
+        }
+
+        if (!function_exists('get_option')) {
+            function get_option(string $key, mixed $default = false): mixed
+            {
+                return $GLOBALS['__phpunit_options'][$key] ?? $default;
+            }
+
+            function update_option(string $key, mixed $value): bool
+            {
+                $GLOBALS['__phpunit_options'][$key] = $value;
+
+                return true;
+            }
+        }
+
+        require_once dirname(__DIR__, 2) . '/wp-content/plugins/aif-donor-space/includes/sales-force/authentification.php';
+
+        $GLOBALS['__phpunit_options'] = [];
+        $GLOBALS['__phpunit_wp_remote_calls'] = [];
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, '{"access_token":"token","issued_at":"1786370000000"}');
+    }
+
+    public function testTransportFailureReturnsExplicitError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = new WP_Error('http_request_failed', 'Connection timed out');
+
+        $result = refresh_salesforce_token_donor_space();
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_transport_error', $result->get_error_code());
+        self::assertSame('oauth_token', $result->get_error_data()['endpoint']);
+        self::assertSame('http_request_failed', $result->get_error_data()['cause_code']);
+    }
+
+    public function testUnauthorizedResponseReturnsAuthenticationError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(401, '{"error":"invalid_client"}');
+
+        $result = refresh_salesforce_token_donor_space();
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_authentication_error', $result->get_error_code());
+        self::assertSame(401, $result->get_error_data()['status']);
+    }
+
+    public function testInvalidJsonReturnsExplicitError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, '<html>Error</html>');
+
+        $result = refresh_salesforce_token_donor_space();
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_invalid_json', $result->get_error_code());
+        self::assertArrayHasKey('json_error', $result->get_error_data());
+    }
+
+    public function testSuccessfulResponseCachesAndReturnsToken(): void
+    {
+        $result = refresh_salesforce_token_donor_space();
+
+        self::assertSame('token', $result);
+        self::assertSame('token', $GLOBALS['__phpunit_options']['salesforce_access_token']);
+        self::assertArrayHasKey('salesforce_token_expiration_time', $GLOBALS['__phpunit_options']);
+    }
+
+    /** @return array{body:string,response:array{code:int}} */
+    private function response(int $status, string $body): array
+    {
+        return [
+            'body' => $body,
+            'response' => ['code' => $status],
+        ];
+    }
+}

--- a/tests/DonorSpace/SalesforceMemberDataTest.php
+++ b/tests/DonorSpace/SalesforceMemberDataTest.php
@@ -94,6 +94,18 @@ final class SalesforceMemberDataTest extends TestCase
             }
         }
 
+        if (!function_exists('amnesty_logo')) {
+            function amnesty_logo(string $url): void
+            {
+            }
+        }
+
+        if (!function_exists('amnesty_nav')) {
+            function amnesty_nav(string $location): void
+            {
+            }
+        }
+
         if (!function_exists('is_page')) {
             function is_page(): bool
             {
@@ -120,9 +132,9 @@ final class SalesforceMemberDataTest extends TestCase
                 return $GLOBALS['__phpunit_post_ancestors'];
             }
 
-            function current_user_can(string $capability): bool
+            function current_user_can(string $capability, mixed ...$args): bool
             {
-                return false;
+                return ($GLOBALS['__phpunit_user_capabilities'][$capability] ?? null) === $args;
             }
         }
 
@@ -149,6 +161,7 @@ final class SalesforceMemberDataTest extends TestCase
         $GLOBALS['__phpunit_singular_post_types'] = [];
         $GLOBALS['__phpunit_queried_object'] = (object) ['ID' => 42, 'post_name' => 'content'];
         $GLOBALS['__phpunit_post_ancestors'] = [];
+        $GLOBALS['__phpunit_user_capabilities'] = [];
         $GLOBALS['wp'] = (object) ['request' => 'mon-espace/mes-dons'];
     }
 
@@ -410,20 +423,26 @@ final class SalesforceMemberDataTest extends TestCase
         self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
     }
 
-    public function testPreviewPreparesMemberContextWithoutApplyingAccessRestriction(): void
+    public function testEditorPreviewSkipsSalesforceAccessCheck(): void
     {
         $GLOBALS['__phpunit_is_page'] = true;
         $GLOBALS['__phpunit_is_preview'] = true;
         $GLOBALS['__phpunit_post_ancestors'] = [1];
-        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(
-            200,
-            '{"Id":"contact-id","isDonateur":true,"isMembre":false,"hasMandatActif":false}'
-        );
+        $GLOBALS['__phpunit_user_capabilities'] = ['edit_post' => [42]];
+        $GLOBALS['__phpunit_wp_remote_response'] = new WP_Error('http_request_failed', 'Must not be called');
 
         auth_my_space();
 
-        self::assertSame('contact-id', aif_get_request_salesforce_member()->Id);
-        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+        self::assertArrayNotHasKey('aif_salesforce_member', $GLOBALS['__phpunit_query_vars']);
+        self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
+
+        ob_start();
+        require dirname(__DIR__, 2) . '/wp-content/themes/humanity-theme/patterns/my-space-sidebar.php';
+        $sidebar = ob_get_clean();
+
+        self::assertIsString($sidebar);
+        self::assertStringContainsString('id="my-space-sidebar"', $sidebar);
+        self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
     }
 
     #[DataProvider('mySpaceSingleProvider')]

--- a/tests/DonorSpace/SalesforceMemberDataTest.php
+++ b/tests/DonorSpace/SalesforceMemberDataTest.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+final class SalesforceServiceUnavailableTestException extends RuntimeException
+{
+    public function __construct(public readonly int $status)
+    {
+        parent::__construct('Salesforce service unavailable');
+    }
+}
+
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
+final class SalesforceMemberDataTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!defined('AIF_SALESFORCE_URL')) {
+            define('AIF_SALESFORCE_URL', 'https://salesforce.example.test/');
+        }
+
+        if (!function_exists('get_salesforce_access_token_donor_space_donor_space')) {
+            function get_salesforce_access_token_donor_space_donor_space(): mixed
+            {
+                return $GLOBALS['__phpunit_donor_space_access_token'];
+            }
+        }
+
+        if (!function_exists('wp_remote_post')) {
+            function wp_remote_post(string $url, array $args = []): mixed
+            {
+                $GLOBALS['__phpunit_wp_remote_calls'][] = ['method' => 'POST', 'url' => $url, 'args' => $args];
+
+                return __phpunit_next_queued_response('__phpunit_wp_remote_response_queue', '__phpunit_wp_remote_response');
+            }
+        }
+
+        if (!function_exists('set_query_var')) {
+            function set_query_var(string $key, mixed $value): void
+            {
+                $GLOBALS['__phpunit_query_vars'][$key] = $value;
+            }
+
+            function get_query_var(string $key, mixed $default = ''): mixed
+            {
+                return $GLOBALS['__phpunit_query_vars'][$key] ?? $default;
+            }
+        }
+
+        if (!function_exists('wp_get_current_user')) {
+            function wp_get_current_user(): object
+            {
+                return $GLOBALS['__phpunit_current_user'];
+            }
+        }
+
+        if (!function_exists('home_url')) {
+            function home_url(string $path = ''): string
+            {
+                return 'https://wordpress.example.test' . $path;
+            }
+        }
+
+        if (!function_exists('add_query_arg')) {
+            function add_query_arg(mixed ...$args): string
+            {
+                return (string) end($args);
+            }
+        }
+
+        if (!function_exists('get_page_by_path')) {
+            function get_page_by_path(string $path): object
+            {
+                return (object) ['ID' => 1, 'post_name' => $path];
+            }
+        }
+
+        if (!function_exists('get_permalink')) {
+            function get_permalink(object|int $post): string
+            {
+                return 'https://wordpress.example.test/connectez-vous/';
+            }
+        }
+
+        if (!function_exists('add_filter')) {
+            function add_filter(string $hook, callable $callback, int $priority = 10, int $accepted_args = 1): void
+            {
+            }
+        }
+
+        if (!function_exists('is_page')) {
+            function is_page(): bool
+            {
+                return $GLOBALS['__phpunit_is_page'];
+            }
+
+            function is_preview(): bool
+            {
+                return $GLOBALS['__phpunit_is_preview'];
+            }
+
+            function is_singular(string $post_type = ''): bool
+            {
+                return in_array($post_type, $GLOBALS['__phpunit_singular_post_types'], true);
+            }
+
+            function get_queried_object(): object
+            {
+                return $GLOBALS['__phpunit_queried_object'];
+            }
+
+            function get_post_ancestors(object|int $post): array
+            {
+                return $GLOBALS['__phpunit_post_ancestors'];
+            }
+
+            function current_user_can(string $capability): bool
+            {
+                return false;
+            }
+        }
+
+        if (!function_exists('wp_die')) {
+            function wp_die(mixed $message = '', mixed $title = '', array $args = []): never
+            {
+                throw new SalesforceServiceUnavailableTestException((int) ($args['response'] ?? 500));
+            }
+        }
+
+        require_once dirname(__DIR__, 2) . '/wp-content/plugins/aif-donor-space/includes/sales-force/user-data.php';
+        require_once dirname(__DIR__, 2) . '/wp-content/plugins/aif-donor-space/includes/authorization.php';
+        require_once dirname(__DIR__, 2) . '/wp-content/themes/humanity-theme/includes/my-space/template.php';
+
+        $GLOBALS['__phpunit_donor_space_access_token'] = 'access-token';
+        $GLOBALS['__phpunit_wp_remote_calls'] = [];
+        $GLOBALS['__phpunit_wp_remote_response_queue'] = [];
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, '{}');
+        $GLOBALS['__phpunit_query_vars'] = [];
+        $GLOBALS['__phpunit_current_user_id'] = 1;
+        $GLOBALS['__phpunit_current_user'] = (object) ['user_email' => 'member@example.test'];
+        $GLOBALS['__phpunit_is_page'] = false;
+        $GLOBALS['__phpunit_is_preview'] = false;
+        $GLOBALS['__phpunit_singular_post_types'] = [];
+        $GLOBALS['__phpunit_queried_object'] = (object) ['ID' => 42, 'post_name' => 'content'];
+        $GLOBALS['__phpunit_post_ancestors'] = [];
+        $GLOBALS['wp'] = (object) ['request' => 'mon-espace/mes-dons'];
+    }
+
+    public function testTransportErrorIsReturnedWithoutOutput(): void
+    {
+        $transport_error = new WP_Error('http_request_failed', 'Connection timed out');
+        $GLOBALS['__phpunit_wp_remote_response'] = $transport_error;
+
+        ob_start();
+        $result = get_salesforce_member_data('timeout@example.test');
+        $output = ob_get_clean();
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_transport_error', $result->get_error_code());
+        self::assertSame('http_request_failed', $result->get_error_data()['cause_code']);
+        self::assertSame(WP_Error::class, $result->get_error_data()['cause_class']);
+        self::assertSame('', $output);
+        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testHttpErrorReturnsWpErrorWithStatus(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(503, '{"message":"Unavailable"}');
+
+        $result = get_salesforce_member_data('http-error@example.test');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_http_error', $result->get_error_code());
+        self::assertSame('GET', $result->get_error_data()['operation']);
+        self::assertSame('member_search', $result->get_error_data()['endpoint']);
+        self::assertSame(503, $result->get_error_data()['status']);
+        self::assertIsInt($result->get_error_data()['duration_ms']);
+    }
+
+    #[DataProvider('httpErrorStatusProvider')]
+    public function testExpectedHttpErrorsRemainExplicit(int $status): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response($status, '{"message":"Request failed"}');
+
+        $result = get_salesforce_member_data('http-error@example.test');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_http_error', $result->get_error_code());
+        self::assertSame($status, $result->get_error_data()['status']);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function httpErrorStatusProvider(): iterable
+    {
+        yield 'unauthorized' => [401];
+        yield 'not found' => [404];
+        yield 'rate limited' => [429];
+        yield 'server error' => [500];
+    }
+
+    public function testEmptyResponseReturnsWpError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, '');
+
+        $result = get_salesforce_member_data('empty-response@example.test');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_empty_response', $result->get_error_code());
+    }
+
+    public function testInvalidJsonReturnsWpError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, '<html>Error</html>');
+
+        $result = get_salesforce_member_data('invalid-json@example.test');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_invalid_json', $result->get_error_code());
+    }
+
+    public function testNullJsonReturnsWpError(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(200, 'null');
+
+        $result = get_salesforce_member_data('null-json@example.test');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_null_response', $result->get_error_code());
+    }
+
+    public function testPostTransportErrorIsReturnedWithoutOutput(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = new WP_Error('http_request_failed', 'Connection timed out');
+
+        ob_start();
+        $result = post_salesforce_data_donor_space('services/data/v57.0/sobjects/Case', []);
+        $output = ob_get_clean();
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_transport_error', $result->get_error_code());
+        self::assertSame('POST', $result->get_error_data()['operation']);
+        self::assertSame('case', $result->get_error_data()['endpoint']);
+        self::assertSame('', $output);
+    }
+
+    public function testPatchNoContentReturnsTrue(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(204, '');
+
+        $result = patch_salesforce_data_donor_space('services/data/v57.0/sobjects/Contact/contact-id', []);
+
+        self::assertTrue($result);
+    }
+
+    public function testAuthenticationErrorIsPropagatedWithoutRequest(): void
+    {
+        $authentication_error = new WP_Error('salesforce_authentication_error', 'Authentication failed');
+        $GLOBALS['__phpunit_donor_space_access_token'] = $authentication_error;
+
+        $result = get_salesforce_member_data('member@example.test');
+
+        self::assertSame($authentication_error, $result);
+        self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testMissingContactIdentifierStopsBeforeHttpRequest(): void
+    {
+        $result = get_salesforce_user_data('');
+
+        self::assertInstanceOf(WP_Error::class, $result);
+        self::assertSame('salesforce_missing_identifier', $result->get_error_code());
+        self::assertSame('contact', $result->get_error_data()['endpoint']);
+        self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testSalesforceLogContextContainsOnlyTechnicalData(): void
+    {
+        $error = new WP_Error('salesforce_http_error', 'Request failed', [
+            'operation' => 'GET',
+            'endpoint' => 'member_search',
+            'duration_ms' => 30001,
+            'status' => 503,
+            'body_size' => 42,
+            'cause_code' => 'http_request_failed',
+            'cause_class' => WP_Error::class,
+            'json_error' => 'Syntax error',
+            'email' => 'private@example.test',
+            'token' => 'secret-token',
+            'body' => '{"private":true}',
+            'url' => 'https://salesforce.example.test/member/private@example.test',
+        ]);
+
+        $context = aif_get_salesforce_log_context($error);
+
+        self::assertSame([
+            'error_code' => 'salesforce_http_error',
+            'error_class' => WP_Error::class,
+            'operation' => 'GET',
+            'endpoint' => 'member_search',
+            'duration_ms' => 30001,
+            'cause_code' => 'http_request_failed',
+            'cause_class' => WP_Error::class,
+            'http_status' => 503,
+            'body_size' => 42,
+            'json_error' => 'Syntax error',
+        ], $context);
+    }
+
+    public function testSalesforceErrorLogFallbackIsStructuredAndAnonymized(): void
+    {
+        $log_file = tempnam(sys_get_temp_dir(), 'aif-salesforce-log-');
+        $previous_log_file = ini_set('error_log', $log_file);
+        $error = new WP_Error('salesforce_http_error', 'Request failed', [
+            'operation' => 'GET',
+            'endpoint' => 'member_search',
+            'status' => 503,
+            'email' => 'private@example.test',
+        ]);
+
+        try {
+            aif_log_salesforce_error($error);
+            $logged_message = file_get_contents($log_file);
+        } finally {
+            ini_set('error_log', (string) $previous_log_file);
+            unlink($log_file);
+        }
+
+        self::assertIsString($logged_message);
+        self::assertStringContainsString('salesforce_http_error', $logged_message);
+        self::assertStringContainsString('"http_status":503', $logged_message);
+        self::assertStringNotContainsString('private@example.test', $logged_message);
+    }
+
+    public function testAccessHelperRejectsErrorsAndIncompleteMembers(): void
+    {
+        $error = new WP_Error('salesforce_request_failed', 'Request failed');
+
+        self::assertFalse(has_access_to_donation_space($error));
+        self::assertFalse(has_access_to_donation_space(null));
+        self::assertFalse(has_access_to_donation_space((object) []));
+
+        $invalid_member = aif_validate_salesforce_member(null);
+        self::assertInstanceOf(WP_Error::class, $invalid_member);
+        self::assertSame('salesforce_invalid_response', $invalid_member->get_error_code());
+    }
+
+    public function testAuthorizedMemberIsSharedThroughTheRequestContext(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(
+            200,
+            '{"Id":"contact-id","isDonateur":true,"isMembre":false,"hasMandatActif":false}'
+        );
+
+        $sf_member = check_user_page_access();
+        set_query_var('aif_salesforce_member', $sf_member);
+
+        self::assertSame($sf_member, aif_get_request_salesforce_member());
+        self::assertSame($sf_member, aif_get_request_salesforce_member());
+        self::assertSame($sf_member, aif_get_request_salesforce_member());
+        self::assertSame('donateur', aif_get_user_status($sf_member));
+        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testEmptyObjectIsAValidAbsentContact(): void
+    {
+        $sf_member = aif_validate_salesforce_member((object) []);
+
+        self::assertInstanceOf(stdClass::class, $sf_member);
+        self::assertTrue(aif_is_salesforce_contact_absent($sf_member));
+        self::assertFalse(has_access_to_donation_space($sf_member));
+    }
+
+    public function testIncompleteMemberIsAnInvalidResponse(): void
+    {
+        $sf_member = aif_validate_salesforce_member((object) [
+            'Id' => 'contact-id',
+            'isDonateur' => true,
+            'isMembre' => false,
+        ]);
+
+        self::assertInstanceOf(WP_Error::class, $sf_member);
+        self::assertSame('salesforce_invalid_response', $sf_member->get_error_code());
+    }
+
+    public function testMemberWithAccessAndNoIdIsAnInvalidResponse(): void
+    {
+        $sf_member = aif_validate_salesforce_member((object) [
+            'Id' => null,
+            'isDonateur' => true,
+            'isMembre' => false,
+            'hasMandatActif' => false,
+        ]);
+
+        self::assertInstanceOf(WP_Error::class, $sf_member);
+        self::assertSame('salesforce_invalid_response', $sf_member->get_error_code());
+    }
+
+    public function testMissingPreparedMemberStopsWithoutNetworkFallback(): void
+    {
+        $this->assertSalesforceServiceUnavailable(function (): void {
+            aif_get_request_salesforce_member();
+        });
+
+        self::assertCount(0, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testPreviewPreparesMemberContextWithoutApplyingAccessRestriction(): void
+    {
+        $GLOBALS['__phpunit_is_page'] = true;
+        $GLOBALS['__phpunit_is_preview'] = true;
+        $GLOBALS['__phpunit_post_ancestors'] = [1];
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(
+            200,
+            '{"Id":"contact-id","isDonateur":true,"isMembre":false,"hasMandatActif":false}'
+        );
+
+        auth_my_space();
+
+        self::assertSame('contact-id', aif_get_request_salesforce_member()->Id);
+        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    #[DataProvider('mySpaceSingleProvider')]
+    public function testMySpaceSinglePreparesMemberContext(string $post_type, string $query_var): void
+    {
+        $GLOBALS['__phpunit_singular_post_types'] = [$post_type];
+        $GLOBALS['__phpunit_query_vars'][$query_var] = 1;
+        $GLOBALS['__phpunit_wp_remote_response'] = $this->response(
+            200,
+            '{"Id":"contact-id","isDonateur":true,"isMembre":true,"hasMandatActif":false}'
+        );
+
+        auth_my_space();
+
+        self::assertSame('contact-id', aif_get_request_salesforce_member()->Id);
+        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function mySpaceSingleProvider(): iterable
+    {
+        yield 'actuality' => ['actualities-my-space', 'unused'];
+        yield 'training' => ['training', 'is_my_space_training'];
+        yield 'petition' => ['petition', 'is_my_space_petition'];
+    }
+
+    public function testMemberLookupFailureStopsAccessWith503AndNoDependentCall(): void
+    {
+        $GLOBALS['__phpunit_wp_remote_response'] = new WP_Error('http_request_failed', 'Connection timed out');
+
+        $this->assertSalesforceServiceUnavailable(function (): void {
+            check_user_page_access();
+        });
+
+        self::assertCount(1, $GLOBALS['__phpunit_wp_remote_calls']);
+    }
+
+    public function testInvalidDependentResponseStopsWith503BeforePropertyAccess(): void
+    {
+        $this->assertSalesforceServiceUnavailable(function (): void {
+            aif_require_salesforce_records((object) ['records' => null], 'sepa_mandates');
+        });
+    }
+
+    private function assertSalesforceServiceUnavailable(callable $callback): void
+    {
+        $log_file = tempnam(sys_get_temp_dir(), 'aif-salesforce-log-');
+        $previous_log_file = ini_set('error_log', $log_file);
+
+        try {
+            $callback();
+            self::fail('The Salesforce failure should stop the request.');
+        } catch (SalesforceServiceUnavailableTestException $exception) {
+            self::assertSame(503, $exception->status);
+        } finally {
+            ini_set('error_log', (string) $previous_log_file);
+            unlink($log_file);
+        }
+    }
+
+    /** @return array{body:string,response:array{code:int}} */
+    private function response(int $status, string $body): array
+    {
+        return [
+            'body' => $body,
+            'response' => ['code' => $status],
+        ];
+    }
+}

--- a/tests/DonorSpace/TaxReceiptTest.php
+++ b/tests/DonorSpace/TaxReceiptTest.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 $posted_salesforce_data_donor_space = [];
+$post_salesforce_data_donor_space_response = (object) ['success' => true];
 $sf_user_ids = [];
+$logged_salesforce_errors = [];
 
-function post_salesforce_data_donor_space(string $url, array $params = []): object
+function post_salesforce_data_donor_space(string $url, array $params = []): mixed
 {
-    global $posted_salesforce_data_donor_space;
+    global $posted_salesforce_data_donor_space, $post_salesforce_data_donor_space_response;
 
     $posted_salesforce_data_donor_space[] = ['url' => $url, 'params' => $params];
 
-    return (object) ['success' => true];
+    return $post_salesforce_data_donor_space_response;
+}
+
+function aif_log_salesforce_error(WP_Error $error): void
+{
+    $GLOBALS['logged_salesforce_errors'][] = $error;
 }
 
 function get_SF_user_ID(int $user_id): string|false
@@ -30,10 +37,12 @@ final class TaxReceiptTest extends TestCase
 {
     protected function setUp(): void
     {
-        global $posted_salesforce_data_donor_space, $sf_user_ids;
+        global $posted_salesforce_data_donor_space, $post_salesforce_data_donor_space_response, $sf_user_ids;
 
         $posted_salesforce_data_donor_space = [];
+        $post_salesforce_data_donor_space_response = (object) ['success' => true];
         $sf_user_ids = [];
+        $GLOBALS['logged_salesforce_errors'] = [];
         $GLOBALS['__phpunit_current_user_id'] = 0;
         $GLOBALS['__phpunit_valid_nonces'] = [];
     }
@@ -124,6 +133,22 @@ final class TaxReceiptTest extends TestCase
 
         self::assertSame(200, $response->get_status());
         self::assertSame('demand succeed', $response->get_data()['message']);
+    }
+
+    public function testHandleRequestReturns503WhenSalesforceFails(): void
+    {
+        global $post_salesforce_data_donor_space_response, $sf_user_ids;
+
+        $error = new WP_Error('salesforce_transport_error', 'Request failed');
+        $post_salesforce_data_donor_space_response = $error;
+        $sf_user_ids[42] = '003-contact-id';
+        $GLOBALS['__phpunit_current_user_id'] = 42;
+
+        $response = handle_duplicate_tax_receipt_request(new WP_REST_Request(['taxReceiptReference' => 'REF-1']));
+
+        self::assertSame(503, $response->get_status());
+        self::assertSame('service temporarily unavailable', $response->get_data()['message']);
+        self::assertSame([$error], $GLOBALS['logged_salesforce_errors']);
     }
 
     public function testCheckNonceRejectsAnInvalidNonce(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -227,6 +227,11 @@ if (!class_exists('WP_Error')) {
         {
             return $this->message;
         }
+
+        public function get_error_data(): mixed
+        {
+            return $this->data;
+        }
     }
 }
 

--- a/wp-content/plugins/aif-donor-space/includes/authorization.php
+++ b/wp-content/plugins/aif-donor-space/includes/authorization.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/sales-force/errors.php';
+
 function aif_salesforce_service_unavailable($error)
 {
     aif_log_salesforce_error($error);

--- a/wp-content/plugins/aif-donor-space/includes/authorization.php
+++ b/wp-content/plugins/aif-donor-space/includes/authorization.php
@@ -1,5 +1,92 @@
 <?php
 
+function aif_salesforce_service_unavailable($error)
+{
+    aif_log_salesforce_error($error);
+    wp_die(
+        AIF_SALESFORCE_SERVICE_UNAVAILABLE_MESSAGE,
+        'Service temporairement indisponible',
+        ['response' => 503]
+    );
+}
+
+function aif_require_salesforce_object($result, $endpoint, $required_property = null)
+{
+    if (is_wp_error($result)) {
+        aif_salesforce_service_unavailable($result);
+    }
+
+    if (!is_object($result) || (null !== $required_property && !property_exists($result, $required_property))) {
+        aif_salesforce_service_unavailable(
+            aif_create_salesforce_invalid_response_error('GET', $endpoint)
+        );
+    }
+
+    return $result;
+}
+
+function aif_require_salesforce_records($result, $endpoint)
+{
+    $result = aif_require_salesforce_object($result, $endpoint, 'records');
+
+    if (!is_array($result->records)) {
+        aif_salesforce_service_unavailable(
+            aif_create_salesforce_invalid_response_error('GET', $endpoint)
+        );
+    }
+
+    return $result;
+}
+
+function aif_require_salesforce_array($result, $endpoint)
+{
+    if (is_wp_error($result)) {
+        aif_salesforce_service_unavailable($result);
+    }
+
+    if (!is_array($result)) {
+        aif_salesforce_service_unavailable(
+            aif_create_salesforce_invalid_response_error('GET', $endpoint)
+        );
+    }
+
+    return $result;
+}
+
+function aif_validate_salesforce_member($sf_member)
+{
+    if (is_wp_error($sf_member)) {
+        return $sf_member;
+    }
+
+    if (!is_object($sf_member)) {
+        return aif_create_salesforce_invalid_response_error('GET', 'member_search');
+    }
+
+    if (aif_is_salesforce_contact_absent($sf_member)) {
+        return $sf_member;
+    }
+
+    $required_properties = ['Id', 'isDonateur', 'isMembre', 'hasMandatActif'];
+
+    foreach ($required_properties as $property) {
+        if (!property_exists($sf_member, $property)) {
+            return aif_create_salesforce_invalid_response_error('GET', 'member_search');
+        }
+    }
+
+    if (empty($sf_member->Id)) {
+        return aif_create_salesforce_invalid_response_error('GET', 'member_search');
+    }
+
+    return $sf_member;
+}
+
+function aif_is_salesforce_contact_absent($sf_member)
+{
+    return is_object($sf_member) && [] === get_object_vars($sf_member);
+}
+
 function check_user_page_access()
 {
     global $wp;
@@ -13,18 +100,33 @@ function check_user_page_access()
     }
 
     $current_user = wp_get_current_user();
-    $sf_user = get_salesforce_member_data($current_user->user_email);
+    $sf_user = aif_validate_salesforce_member(get_salesforce_member_data($current_user->user_email));
 
+    if (is_wp_error($sf_user)) {
+        aif_salesforce_service_unavailable($sf_user);
+    }
 
-    if (!$sf_user) {
+    if (aif_is_salesforce_contact_absent($sf_user) || !has_access_to_donation_space($sf_user)) {
         wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
         exit;
     }
 
+    return $sf_user;
+}
 
-    if (!has_access_to_donation_space($sf_user)) {
-        wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
-        exit;
+function aif_get_request_salesforce_member()
+{
+    $sf_member = get_query_var('aif_salesforce_member', null);
+
+    if (is_wp_error($sf_member)) {
+        aif_salesforce_service_unavailable($sf_member);
     }
 
+    if (!is_object($sf_member)) {
+        aif_salesforce_service_unavailable(
+            aif_create_salesforce_invalid_response_error('GET', 'member_search')
+        );
+    }
+
+    return $sf_member;
 }

--- a/wp-content/plugins/aif-donor-space/includes/domain/tax-receipt/rest-controllers.php
+++ b/wp-content/plugins/aif-donor-space/includes/domain/tax-receipt/rest-controllers.php
@@ -23,8 +23,13 @@ function handle_duplicate_tax_receipt_request(WP_REST_Request $request)
 
     $result = create_duplicate_taxt_receipt_request($SF_ID, $taxt_receipt_reference);
 
-    if (!$result->success) {
-        return new WP_REST_Response(['message' => 'demand failed', 'result' => $result], status: 400);
+    if (is_wp_error($result)) {
+        aif_log_salesforce_error($result);
+        return new WP_REST_Response(['message' => 'service temporarily unavailable'], status: 503);
+    }
+
+    if (!is_object($result) || empty($result->success)) {
+        return new WP_REST_Response(['message' => 'demand failed'], status: 400);
     }
 
     $response = [

--- a/wp-content/plugins/aif-donor-space/includes/sales-force/authentification.php
+++ b/wp-content/plugins/aif-donor-space/includes/sales-force/authentification.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/errors.php';
+
 function get_salesforce_access_token_donor_space_donor_space()
 {
     $access_token = get_option('salesforce_access_token');
@@ -19,6 +21,7 @@ function get_salesforce_access_token_donor_space_donor_space()
 
 function refresh_salesforce_token_donor_space()
 {
+    $started_at = microtime(true);
     $aif_salesforce_base_url = defined('AIF_SALESFORCE_URL') ? AIF_SALESFORCE_URL : getenv('AIF_SALESFORCE_URL');
     $client_id = defined('AIF_SALESFORCE_CLIENT_ID') ? AIF_SALESFORCE_CLIENT_ID : getenv('AIF_SALESFORCE_CLIENT_ID');
     $client_secret = defined('AIF_SALESFORCE_SECRET') ? AIF_SALESFORCE_SECRET : getenv('AIF_SALESFORCE_SECRET');
@@ -40,24 +43,70 @@ function refresh_salesforce_token_donor_space()
     ]);
 
     if (is_wp_error($response)) {
-        return new WP_Error('request_failed', 'La requête a échoué', $response->get_error_message());
+        return aif_create_salesforce_transport_error($response, 'OAUTH', $url, $started_at);
     }
 
+    $status_code = wp_remote_retrieve_response_code($response);
     $body = wp_remote_retrieve_body($response);
+    $response_data = [
+        'status' => $status_code,
+        'body_size' => strlen($body),
+    ];
 
-    $data = json_decode($body, true);
+    if ($status_code < 200 || $status_code >= 300) {
+        $error_code = in_array($status_code, [400, 401, 403], true)
+            ? 'salesforce_authentication_error'
+            : 'salesforce_http_error';
 
-    if (isset($data['access_token'])) {
-
-        $issued_at = intval($data['issued_at']); // warning : this is ms and not seconds
-        $expiration_interval = 10 * 60 * 1000; // 10 minutes in milliseconds
-        $expiration_time = $issued_at + $expiration_interval ;
-
-        update_option('salesforce_access_token', $data['access_token']);
-        update_option('salesforce_token_expiration_time', $expiration_time);
-
-        return $data['access_token'];
-    } else {
-        return new WP_Error('token_refresh_failed', 'Le rafraîchissement du token a échoué', $data);
+        return new WP_Error(
+            $error_code,
+            'L’authentification Salesforce a échoué.',
+            aif_get_salesforce_error_data('OAUTH', $url, $started_at, $response_data)
+        );
     }
+
+    if ('' === trim($body)) {
+        return new WP_Error(
+            'salesforce_empty_response',
+            'Salesforce a retourné une réponse vide.',
+            aif_get_salesforce_error_data('OAUTH', $url, $started_at, $response_data)
+        );
+    }
+
+    try {
+        $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $exception) {
+        return new WP_Error(
+            'salesforce_invalid_json',
+            'Salesforce a retourné une réponse JSON invalide.',
+            aif_get_salesforce_error_data('OAUTH', $url, $started_at, array_merge($response_data, [
+                'json_error' => $exception->getMessage(),
+            ]))
+        );
+    }
+
+    if (null === $data) {
+        return new WP_Error(
+            'salesforce_null_response',
+            'Salesforce a retourné une réponse nulle.',
+            aif_get_salesforce_error_data('OAUTH', $url, $started_at, $response_data)
+        );
+    }
+
+    if (!is_array($data) || empty($data['access_token']) || empty($data['issued_at'])) {
+        return new WP_Error(
+            'salesforce_invalid_response',
+            'La réponse d’authentification Salesforce est invalide.',
+            aif_get_salesforce_error_data('OAUTH', $url, $started_at, $response_data)
+        );
+    }
+
+    $issued_at = intval($data['issued_at']); // warning : this is ms and not seconds
+    $expiration_interval = 10 * 60 * 1000; // 10 minutes in milliseconds
+    $expiration_time = $issued_at + $expiration_interval ;
+
+    update_option('salesforce_access_token', $data['access_token']);
+    update_option('salesforce_token_expiration_time', $expiration_time);
+
+    return $data['access_token'];
 }

--- a/wp-content/plugins/aif-donor-space/includes/sales-force/errors.php
+++ b/wp-content/plugins/aif-donor-space/includes/sales-force/errors.php
@@ -1,0 +1,188 @@
+<?php
+
+const AIF_SALESFORCE_SERVICE_UNAVAILABLE_MESSAGE = 'Votre espace est temporairement indisponible. Merci de réessayer dans quelques instants.';
+
+function aif_get_salesforce_endpoint_name($url)
+{
+    $routes = [
+        'services/oauth2/token' => 'oauth_token',
+        'services/apexrest/search/v1/' => 'member_search',
+        'RecuFiscaux' => 'tax_receipts',
+        'Demandes' => 'demands',
+        'Mandats_SEPA__r' => 'sepa_mandates',
+        'sobjects/Contact/' => 'contact',
+        'sobjects/Case' => 'case',
+    ];
+
+    foreach ($routes as $route => $endpoint) {
+        if (false !== strpos((string) $url, $route)) {
+            return $endpoint;
+        }
+    }
+
+    return 'salesforce_api';
+}
+
+function aif_get_salesforce_error_data($operation, $url, $started_at, $data = [])
+{
+    return array_merge([
+        'operation' => strtoupper((string) $operation),
+        'endpoint' => aif_get_salesforce_endpoint_name($url),
+        'duration_ms' => max(0, (int) round((microtime(true) - $started_at) * 1000)),
+    ], $data);
+}
+
+function aif_create_salesforce_transport_error($error, $operation, $url, $started_at)
+{
+    return new WP_Error(
+        'salesforce_transport_error',
+        'La requête Salesforce a échoué.',
+        aif_get_salesforce_error_data($operation, $url, $started_at, [
+            'cause_code' => $error->get_error_code(),
+            'cause_class' => get_class($error),
+        ])
+    );
+}
+
+function aif_create_salesforce_invalid_response_error($operation, $endpoint)
+{
+    return new WP_Error(
+        'salesforce_invalid_response',
+        'La réponse Salesforce est invalide.',
+        [
+            'operation' => strtoupper((string) $operation),
+            'endpoint' => (string) $endpoint,
+        ]
+    );
+}
+
+function aif_create_salesforce_missing_identifier_error($operation, $endpoint)
+{
+    return new WP_Error(
+        'salesforce_missing_identifier',
+        'L’identifiant Salesforce requis est absent.',
+        [
+            'operation' => strtoupper((string) $operation),
+            'endpoint' => (string) $endpoint,
+        ]
+    );
+}
+
+function aif_get_salesforce_log_context($error)
+{
+    $error_data = $error->get_error_data();
+    $error_data = is_array($error_data) ? $error_data : [];
+    $context = [
+        'error_code' => $error->get_error_code(),
+        'error_class' => get_class($error),
+    ];
+    $allowed_fields = [
+        'operation' => 'operation',
+        'endpoint' => 'endpoint',
+        'duration_ms' => 'duration_ms',
+        'cause_code' => 'cause_code',
+        'cause_class' => 'cause_class',
+        'status' => 'http_status',
+        'body_size' => 'body_size',
+        'json_error' => 'json_error',
+    ];
+
+    foreach ($allowed_fields as $source => $destination) {
+        if (array_key_exists($source, $error_data)) {
+            $context[$destination] = $error_data[$source];
+        }
+    }
+
+    return $context;
+}
+
+function aif_log_salesforce_error($error)
+{
+    if (!is_wp_error($error)) {
+        return;
+    }
+
+    $context = aif_get_salesforce_log_context($error);
+    $message = sprintf('Salesforce request failed: %s', $error->get_error_code());
+    $sentry_enabled = defined('WP_SENTRY_PHP_DSN')
+        && !empty(WP_SENTRY_PHP_DSN)
+        && function_exists('Sentry\\withScope')
+        && function_exists('Sentry\\captureMessage')
+        && class_exists('Sentry\\Severity');
+
+    if ($sentry_enabled) {
+        call_user_func('Sentry\\withScope', function ($scope) use ($context, $message) {
+            $scope->setTag('salesforce.error_code', $context['error_code']);
+
+            if (isset($context['endpoint'])) {
+                $scope->setTag('salesforce.endpoint', $context['endpoint']);
+            }
+
+            $scope->setContext('salesforce', $context);
+            $severity_class = 'Sentry\\Severity';
+            call_user_func('Sentry\\captureMessage', $message, $severity_class::error());
+        });
+
+        return;
+    }
+
+    $encoded_context = function_exists('wp_json_encode')
+        ? wp_json_encode($context)
+        : json_encode($context);
+
+    error_log(sprintf('%s %s', $message, $encoded_context ?: '{}'));
+}
+
+function aif_parse_salesforce_response($response, $operation, $url, $started_at, $allow_no_content = false)
+{
+    if (is_wp_error($response)) {
+        return aif_create_salesforce_transport_error($response, $operation, $url, $started_at);
+    }
+
+    $status_code = wp_remote_retrieve_response_code($response);
+    $body = wp_remote_retrieve_body($response);
+    $response_data = [
+        'status' => $status_code,
+        'body_size' => strlen($body),
+    ];
+
+    if ($status_code < 200 || $status_code >= 300) {
+        return new WP_Error(
+            'salesforce_http_error',
+            'La requête Salesforce a échoué.',
+            aif_get_salesforce_error_data($operation, $url, $started_at, $response_data)
+        );
+    }
+
+    if ($allow_no_content && 204 === $status_code && '' === trim($body)) {
+        return true;
+    }
+
+    if ('' === trim($body)) {
+        return new WP_Error(
+            'salesforce_empty_response',
+            'Salesforce a retourné une réponse vide.',
+            aif_get_salesforce_error_data($operation, $url, $started_at, $response_data)
+        );
+    }
+
+    try {
+        $decoded_data = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
+    } catch (JsonException $exception) {
+        return new WP_Error(
+            'salesforce_invalid_json',
+            'Salesforce a retourné une réponse JSON invalide.',
+            aif_get_salesforce_error_data($operation, $url, $started_at, array_merge($response_data, [
+                'json_error' => $exception->getMessage(),
+            ]))
+        );
+    }
+
+    return null === $decoded_data
+        ? new WP_Error(
+            'salesforce_null_response',
+            'Salesforce a retourné une réponse nulle.',
+            aif_get_salesforce_error_data($operation, $url, $started_at, $response_data)
+        )
+        : $decoded_data;
+}

--- a/wp-content/plugins/aif-donor-space/includes/sales-force/user-data.php
+++ b/wp-content/plugins/aif-donor-space/includes/sales-force/user-data.php
@@ -1,13 +1,14 @@
 <?php
 
+require_once __DIR__ . '/errors.php';
 
 function post_salesforce_data_donor_space($url, $params = [])
 {
+    $started_at = microtime(true);
     $access_token = get_salesforce_access_token_donor_space_donor_space();
 
     if (is_wp_error($access_token)) {
-        echo 'Erreur : ' . $access_token->get_error_message();
-        exit;
+        return $access_token;
     }
 
     $aif_salesforce_base_url = defined('AIF_SALESFORCE_URL') ? AIF_SALESFORCE_URL : getenv('AIF_SALESFORCE_URL');
@@ -21,22 +22,16 @@ function post_salesforce_data_donor_space($url, $params = [])
         ],
     ]);
 
-    if (is_wp_error($response)) {
-        echo 'Erreur de requête Salesforce : ' . $response->get_error_message();
-        return false;
-    } else {
-        $data = wp_remote_retrieve_body($response);
-        return json_decode($data);
-    }
+    return aif_parse_salesforce_response($response, 'POST', $url, $started_at);
 }
 
 function patch_salesforce_data_donor_space($url, $params = [])
 {
+    $started_at = microtime(true);
     $access_token = get_salesforce_access_token_donor_space_donor_space();
 
     if (is_wp_error($access_token)) {
-        echo 'Erreur : ' . $access_token->get_error_message();
-        exit;
+        return $access_token;
     }
 
     $aif_salesforce_base_url = defined('AIF_SALESFORCE_URL') ? AIF_SALESFORCE_URL : getenv('AIF_SALESFORCE_URL');
@@ -50,23 +45,17 @@ function patch_salesforce_data_donor_space($url, $params = [])
         ],
     ]);
 
-    if (is_wp_error($response)) {
-        echo 'Erreur de requête Salesforce : ' . $response->get_error_message();
-        return false;
-    } else {
-        $data = wp_remote_retrieve_body($response);
-        return json_decode($data);
-    }
+    return aif_parse_salesforce_response($response, 'PATCH', $url, $started_at, true);
 }
 
 
 function get_salesforce_data_donor_space($url)
 {
+    $started_at = microtime(true);
     $access_token = get_salesforce_access_token_donor_space_donor_space();
 
     if (is_wp_error($access_token)) {
-        echo 'Erreur : ' . $access_token->get_error_message();
-        exit;
+        return $access_token;
     }
 
     $aif_salesforce_base_url = defined('AIF_SALESFORCE_URL') ? AIF_SALESFORCE_URL : getenv('AIF_SALESFORCE_URL');
@@ -77,12 +66,7 @@ function get_salesforce_data_donor_space($url)
         'timeout' => 30,
     ]);
 
-    if (is_wp_error($response)) {
-        echo 'Erreur de requête Salesforce : ' . $response->get_error_message();
-    } else {
-        $data = wp_remote_retrieve_body($response);
-        return json_decode($data);
-    }
+    return aif_parse_salesforce_response($response, 'GET', $url, $started_at);
 }
 
 
@@ -94,12 +78,20 @@ function get_salesforce_member_data($email)
 
 function get_salesforce_user_data($ID)
 {
+    if (empty($ID)) {
+        return aif_create_salesforce_missing_identifier_error('GET', 'contact');
+    }
+
     $url = 'services/data/v57.0/sobjects/Contact/' . $ID;
     return get_salesforce_data_donor_space($url);
 }
 
 function patch_salesforce_user_data($userData, $ID)
 {
+    if (empty($ID)) {
+        return aif_create_salesforce_missing_identifier_error('PATCH', 'contact');
+    }
+
     $url = 'services/data/v57.0/sobjects/Contact/' . $ID;
     return patch_salesforce_data_donor_space($url, $userData);
 }
@@ -108,16 +100,28 @@ function patch_salesforce_user_data($userData, $ID)
 
 function has_access_to_donation_space($sf_user)
 {
-    return $sf_user->isDonateur || $sf_user->isMembre;
+    if (is_wp_error($sf_user) || !is_object($sf_user)) {
+        return false;
+    }
+
+    return !empty($sf_user->isDonateur) || !empty($sf_user->isMembre);
 }
 function get_salesforce_user_tax_reciept($ID)
 {
+    if (empty($ID)) {
+        return aif_create_salesforce_missing_identifier_error('GET', 'tax_receipts');
+    }
+
     $url = '/services/apexrest/retrieve/v1/RecuFiscaux/?idContact='.$ID;
     return get_salesforce_data_donor_space($url);
 }
 
 function get_salesforce_user_SEPA_mandate($ID)
 {
+    if (empty($ID)) {
+        return aif_create_salesforce_missing_identifier_error('GET', 'sepa_mandates');
+    }
+
     $url = 'services/data/v57.0/sobjects/Contact/'.$ID.'/Mandats_SEPA__r?fields=Id,Name,RUM__c,Montant__c,Statut__c,Periodicite__c,Date_paiement_Avenir__c,Tech_Iban__c';
     return get_salesforce_data_donor_space($url);
 }
@@ -151,19 +155,24 @@ function get_email_token($user_id)
 
 function aif_get_user_status($sf_user)
 {
-
-    if ($sf_user->isMembre == true) {
+    if (true === $sf_user->isMembre) {
         return 'membre';
     }
 
-    if ($sf_user->isDonateur == true) {
+    if (true === $sf_user->isDonateur) {
         return 'donateur';
     }
+
+    return '';
 }
 
 
 function get_salesforce_user_demands($ID)
 {
+    if (empty($ID)) {
+        return aif_create_salesforce_missing_identifier_error('GET', 'demands');
+    }
+
     $url = '/services/apexrest/retrieve/v1/Demandes/?idContact=' . $ID;
     return get_salesforce_data_donor_space($url);
 }

--- a/wp-content/themes/humanity-theme/includes/my-space/template.php
+++ b/wp-content/themes/humanity-theme/includes/my-space/template.php
@@ -56,13 +56,13 @@ function auth_my_space()
         return;
     }
 
+    if (is_preview() && current_user_can('edit_post', $current_page->ID)) {
+        return;
+    }
+
     $sf_member = check_user_page_access();
 
     set_query_var('aif_salesforce_member', $sf_member);
-
-    if (is_preview()) {
-        return;
-    }
 
     aif_restrict_my_space_access($sf_member, $current_page, $parent_page);
 }

--- a/wp-content/themes/humanity-theme/includes/my-space/template.php
+++ b/wp-content/themes/humanity-theme/includes/my-space/template.php
@@ -37,24 +37,42 @@ function auth_my_space()
 {
     $slug_parent_page = 'mon-espace';
 
-    if (is_page() && ! is_preview()) {
-        $current_page = get_queried_object();
+    $current_page = get_queried_object();
+    $parent_page = get_page_by_path($slug_parent_page);
 
-        $parent_page = get_page_by_path($slug_parent_page);
-
-        if ($parent_page) {
-            $id_parent_page = $parent_page->ID;
-
-            $ancestors = get_post_ancestors($current_page->ID);
-
-            if ($current_page->ID === $id_parent_page || in_array($id_parent_page, $ancestors)) {
-                check_user_page_access();
-            }
-        }
+    if (!$current_page || !$parent_page) {
+        return;
     }
+
+    $is_my_space_page = false;
+
+    if (is_page()) {
+        $ancestors = get_post_ancestors($current_page->ID);
+        $is_my_space_page = $current_page->ID === $parent_page->ID
+            || in_array($parent_page->ID, $ancestors, true);
+    }
+
+    if (!$is_my_space_page && !aif_is_my_space_single()) {
+        return;
+    }
+
+    $sf_member = check_user_page_access();
+
+    set_query_var('aif_salesforce_member', $sf_member);
+
+    if (is_preview()) {
+        return;
+    }
+
+    aif_restrict_my_space_access($sf_member, $current_page, $parent_page);
 }
 
-add_action('template_redirect', 'aif_restrict_my_space_access');
+function aif_is_my_space_single()
+{
+    return is_singular('actualities-my-space')
+        || (is_singular('training') && get_query_var('is_my_space_training'))
+        || (is_singular('petition') && get_query_var('is_my_space_petition'));
+}
 
 add_filter('logout_redirect', 'aif_my_space_logout_redirect', 10, 2);
 
@@ -67,28 +85,9 @@ function aif_my_space_logout_redirect($redirect_to, $requested_redirect_to)
     return home_url('/');
 }
 
-function aif_restrict_my_space_access()
+function aif_restrict_my_space_access($sf_member, $current_page, $parent_page)
 {
-    $my_space_parent_slug = 'mon-espace';
-
-    if (!is_page()) {
-        return;
-    }
-
-    $parent_page = get_page_by_path($my_space_parent_slug);
-
-    if (!$parent_page) {
-        return;
-    }
-
-    global $post;
-    $ancestors = get_post_ancestors($post);
-
-    if ($post->ID !== $parent_page->ID && !in_array($parent_page->ID, $ancestors)) {
-        return;
-    }
-
-    if (!is_user_logged_in() || current_user_can('manage_options')) {
+    if (current_user_can('manage_options')) {
         return;
     }
 
@@ -102,30 +101,18 @@ function aif_restrict_my_space_access()
         'se-deconnecter',
     ];
 
-    $is_member = false;
-    $current_user = wp_get_current_user();
-
-    if (function_exists('get_salesforce_member_data')) {
-        $sf_member = get_salesforce_member_data($current_user->user_email);
-
-        if (isset($sf_member) && !empty($sf_member->isMembre)) {
-            $is_member = true;
-        }
-    }
-
-    if ($is_member) {
+    if (!empty($sf_member->isMembre)) {
         return;
     }
 
-    $non_member_homepage = home_url('/' . $my_space_parent_slug . '/' . $allowed_for_non_members[0] . '/');
+    $non_member_homepage = home_url('/mon-espace/' . $allowed_for_non_members[0] . '/');
 
-    if (is_page($my_space_parent_slug)) {
+    if ($current_page->ID === $parent_page->ID) {
         wp_redirect($non_member_homepage);
         exit;
     }
 
-    $current_page_slug = get_post()->post_name;
-    if (!in_array($current_page_slug, $allowed_for_non_members)) {
+    if (!in_array($current_page->post_name, $allowed_for_non_members)) {
         wp_redirect($non_member_homepage);
         exit;
     }

--- a/wp-content/themes/humanity-theme/page-connectez-vous.php
+++ b/wp-content/themes/humanity-theme/page-connectez-vous.php
@@ -1,11 +1,11 @@
 <?php
 
 $email = '';
+$title = 'Une erreur est survenue';
 
 $reset_email_url = '';
 
 if (!isset($_GET['user'])) {
-    $error_title = 'Une erreur est survenue';
     $error_message = "Nous ne pouvons récupérer l'utilisateur associé à l'identifiant.";
 
 } else {
@@ -37,17 +37,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email']) && isset($_P
                     'remember' => true,
                 ];
 
-                $sf_member = get_salesforce_member_data($email);
-                store_SF_user_ID($stored_user->ID, $sf_member->Id);
-                $user = wp_signon($creds, true);
-
-                if (!is_wp_error($user)) {
-                    wp_set_current_user($user->ID);
-                    $verification_url = get_permalink(get_page_by_path('mon-espace'));
-                    wp_redirect($_GET['redirect_to'] ?? $verification_url);
-                    exit;
+                $sf_member = aif_validate_salesforce_member(get_salesforce_member_data($email));
+                if (is_wp_error($sf_member)) {
+                    aif_log_salesforce_error($sf_member);
+                    $error_message = AIF_SALESFORCE_SERVICE_UNAVAILABLE_MESSAGE;
+                } elseif (aif_is_salesforce_contact_absent($sf_member) || !has_access_to_donation_space($sf_member)) {
+                    $error_message = "L'adresse email renseignée ne trouve pas de correspondance dans notre système";
                 } else {
-                    $error_message = 'Mauvais email ou mot de passe';
+                    store_SF_user_ID($stored_user->ID, $sf_member->Id);
+                    $user = wp_signon($creds, true);
+
+                    if (!is_wp_error($user)) {
+                        wp_set_current_user($user->ID);
+                        $verification_url = get_permalink(get_page_by_path('mon-espace'));
+                        wp_redirect($_GET['redirect_to'] ?? $verification_url);
+                        exit;
+                    } else {
+                        $error_message = 'Mauvais email ou mot de passe';
+                    }
                 }
 
             } else {

--- a/wp-content/themes/humanity-theme/page-creer-votre-compte.php
+++ b/wp-content/themes/humanity-theme/page-creer-votre-compte.php
@@ -1,66 +1,108 @@
 <?php
 
-$error_message = '';
-$error_no_access_to_donor_space = false;
+function aif_account_creation_result($error_message = '', $no_access = false)
+{
+    return [
+        'error_message' => $error_message,
+        'no_access' => $no_access,
+    ];
+}
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+function aif_account_creation_salesforce_error_result(WP_Error $error)
+{
+    aif_log_salesforce_error($error);
+
+    return aif_account_creation_result(AIF_SALESFORCE_SERVICE_UNAVAILABLE_MESSAGE);
+}
+
+function aif_handle_account_creation_request()
+{
+    if ('POST' !== $_SERVER['REQUEST_METHOD']) {
+        return aif_account_creation_result();
+    }
 
     $turnstile_error = verify_turnstile();
-    if ($turnstile_error !== null) {
-        $error_message = turnstile_friendly_error($turnstile_error);
-    } else {
-        $email = sanitize_email($_POST['email']);
-        $password = sanitize_text_field($_POST['password']);
-        $confirm_password = sanitize_text_field($_POST['confirm-password']);
-
-        if (empty($email) || empty($password)) {
-            $error_message = 'Veuillez renseigner le mot de passe et votre email';
-        } elseif (!is_email($email)) {
-            $error_message = "L'email renseigné est invalide";
-
-        } elseif ($password !== $confirm_password) {
-            $error_message = 'Les mots de passe ne correspondent pas';
-        } else {
-
-            $sf_member = get_salesforce_member_data($email);
-
-            if (has_access_to_donation_space($sf_member)) {
-                $user = get_salesforce_user_data($sf_member->Id);
-
-                $userdata = [
-                    'user_login' => $email,
-                    'user_email' => $email,
-                    'user_pass' => $password,
-                    'first_name' => $user->FirstName,
-                    'last_name' => $user->LastName,
-                    'nickname' => $user->FirstName . ' ' . $user->LastName,
-                    'role' => 'subscriber'];
-
-                $user_id = wp_insert_user($userdata);
-
-                if (!is_wp_error($user_id)) {
-                    $code = generate_2fa_code();
-                    store_2fa_code($user_id, $code);
-
-                    $verification_url = add_query_arg([
-                        'user' => $email,
-                    ], get_permalink(get_page_by_path('verifier-votre-email')));
-
-                    if (send_2fa_code($email, $code)) {
-                        wp_redirect($verification_url);
-                        exit;
-                    }
-                } else {
-                    $url = get_permalink(get_page_by_path('connectez-vous'));
-                    $error_message = "Vous semblez déjà avoir un compte espace don. Pour vous rendre sur votre Espace Don rendez-vous sur  <a class='aif-link--primary' href='{$url}'>{$url}</a>.";
-                }
-
-            } else {
-                $error_no_access_to_donor_space = true;
-            }
-        }
+    if (null !== $turnstile_error) {
+        return aif_account_creation_result(turnstile_friendly_error($turnstile_error));
     }
+
+    $email = sanitize_email($_POST['email'] ?? '');
+    $password = sanitize_text_field($_POST['password'] ?? '');
+    $confirm_password = sanitize_text_field($_POST['confirm-password'] ?? '');
+
+    if (empty($email) || empty($password)) {
+        return aif_account_creation_result('Veuillez renseigner le mot de passe et votre email');
+    }
+
+    if (!is_email($email)) {
+        return aif_account_creation_result("L'email renseigné est invalide");
+    }
+
+    if ($password !== $confirm_password) {
+        return aif_account_creation_result('Les mots de passe ne correspondent pas');
+    }
+
+    $sf_member = aif_validate_salesforce_member(get_salesforce_member_data($email));
+
+    if (is_wp_error($sf_member)) {
+        return aif_account_creation_salesforce_error_result($sf_member);
+    }
+
+    if (aif_is_salesforce_contact_absent($sf_member) || !has_access_to_donation_space($sf_member)) {
+        return aif_account_creation_result(no_access: true);
+    }
+
+    $user = get_salesforce_user_data($sf_member->Id);
+
+    if (is_wp_error($user)) {
+        return aif_account_creation_salesforce_error_result($user);
+    }
+
+    if (!is_object($user)) {
+        return aif_account_creation_salesforce_error_result(
+            aif_create_salesforce_invalid_response_error('GET', 'contact')
+        );
+    }
+
+    $first_name = $user->FirstName ?? '';
+    $last_name = $user->LastName ?? '';
+    $userdata = [
+        'user_login' => $email,
+        'user_email' => $email,
+        'user_pass' => $password,
+        'first_name' => $first_name,
+        'last_name' => $last_name,
+        'nickname' => trim($first_name . ' ' . $last_name),
+        'role' => 'subscriber',
+    ];
+
+    $user_id = wp_insert_user($userdata);
+
+    if (is_wp_error($user_id)) {
+        $url = get_permalink(get_page_by_path('connectez-vous'));
+        return aif_account_creation_result(
+            "Vous semblez déjà avoir un compte espace don. Pour vous rendre sur votre Espace Don rendez-vous sur  <a class='aif-link--primary' href='{$url}'>{$url}</a>."
+        );
+    }
+
+    $code = generate_2fa_code();
+    store_2fa_code($user_id, $code);
+
+    $verification_url = add_query_arg([
+        'user' => $email,
+    ], get_permalink(get_page_by_path('verifier-votre-email')));
+
+    if (send_2fa_code($email, $code)) {
+        wp_redirect($verification_url);
+        exit;
+    }
+
+    return aif_account_creation_result();
 }
+
+$account_creation_result = aif_handle_account_creation_request();
+$error_message = $account_creation_result['error_message'];
+$error_no_access_to_donor_space = $account_creation_result['no_access'];
 
 ?>
 

--- a/wp-content/themes/humanity-theme/page-mes-demandes.php
+++ b/wp-content/themes/humanity-theme/page-mes-demandes.php
@@ -1,8 +1,8 @@
 <?php
 
-$current_user = wp_get_current_user();
-$sf_user_ID = get_SF_user_ID($current_user->ID);
-$demands =  get_salesforce_user_demands($sf_user_ID);
+$sf_member = aif_get_request_salesforce_member();
+$sf_user_ID = $sf_member->Id;
+$demands = aif_require_salesforce_array(get_salesforce_user_demands($sf_user_ID), 'demands');
 $sortedDemands = sortByDateProp($demands, 'Date_de_la_demande__c');
 
 function aif_format_date($date)
@@ -91,4 +91,3 @@ function aif_format_date($date)
 </div>
 
 <?php get_footer(); ?>
-

--- a/wp-content/themes/humanity-theme/page-mes-dons.php
+++ b/wp-content/themes/humanity-theme/page-mes-dons.php
@@ -1,8 +1,8 @@
 <?php
 
 $current_user = wp_get_current_user();
-$sf_member = get_salesforce_member_data($current_user->user_email);
-$sf_user = get_salesforce_user_data($sf_member->Id);
+$sf_member = aif_get_request_salesforce_member();
+$sf_user = aif_require_salesforce_object(get_salesforce_user_data($sf_member->Id), 'contact', 'Id');
 $user_status =  aif_get_user_status($sf_member);
 
 ?>

--- a/wp-content/themes/humanity-theme/page-mes-informations-personnelles.php
+++ b/wp-content/themes/humanity-theme/page-mes-informations-personnelles.php
@@ -1,11 +1,14 @@
 <?php
 
 $current_user = wp_get_current_user();
-$sf_user_ID = get_SF_user_ID($current_user->ID);
+$sf_member = aif_get_request_salesforce_member();
+$sf_user_ID = $sf_member->Id;
 
-$sf_user = get_salesforce_user_data($sf_user_ID);
-$sf_member = get_salesforce_member_data($current_user->user_email);
-$SEPA_mandates = get_salesforce_user_SEPA_mandate($sf_user_ID);
+$sf_user = aif_require_salesforce_object(get_salesforce_user_data($sf_user_ID), 'contact', 'Id');
+$SEPA_mandates = aif_require_salesforce_records(
+    get_salesforce_user_SEPA_mandate($sf_user_ID),
+    'sepa_mandates'
+);
 
 $actifMandate  = null;
 $day_of_payment = null;
@@ -94,8 +97,13 @@ if (checkKeys($requiredFields, $_POST) && $_SERVER['REQUEST_METHOD'] === 'POST')
     ];
 
     $data  = array_merge($_POST, $partial_data);
-    patch_salesforce_user_data($data, $sf_user_ID);
-    $sf_user = get_salesforce_user_data($sf_user_ID);
+    $patch_result = patch_salesforce_user_data($data, $sf_user_ID);
+
+    if (is_wp_error($patch_result)) {
+        aif_salesforce_service_unavailable($patch_result);
+    }
+
+    $sf_user = aif_require_salesforce_object(get_salesforce_user_data($sf_user_ID), 'contact', 'Id');
     $action_succeed = true;
 }
 

--- a/wp-content/themes/humanity-theme/page-mes-recus-fiscaux.php
+++ b/wp-content/themes/humanity-theme/page-mes-recus-fiscaux.php
@@ -1,8 +1,8 @@
 <?php
 
-$current_user = wp_get_current_user();
-$sf_user_ID = get_SF_user_ID($current_user->ID);
-$tax_reciept = get_salesforce_user_tax_reciept($sf_user_ID);
+$sf_member = aif_get_request_salesforce_member();
+$sf_user_ID = $sf_member->Id;
+$tax_reciept = aif_require_salesforce_array(get_salesforce_user_tax_reciept($sf_user_ID), 'tax_receipts');
 
 $sorted = [];
 $groupped = [];

--- a/wp-content/themes/humanity-theme/page-modification-coordonnees-bancaire.php
+++ b/wp-content/themes/humanity-theme/page-modification-coordonnees-bancaire.php
@@ -1,11 +1,13 @@
 <?php
 
-$current_user = wp_get_current_user();
-$sf_user_ID = get_SF_user_ID($current_user->ID);
+$SF_membre_data = aif_get_request_salesforce_member();
+$sf_user_ID = $SF_membre_data->Id;
 
-$SF_User = get_salesforce_user_data($sf_user_ID);
-$SF_membre_data = get_salesforce_member_data($current_user->user_email);
-$SEPA_mandates = get_salesforce_user_SEPA_mandate($sf_user_ID);
+$SF_User = aif_require_salesforce_object(get_salesforce_user_data($sf_user_ID), 'contact', 'Id');
+$SEPA_mandates = aif_require_salesforce_records(
+    get_salesforce_user_SEPA_mandate($sf_user_ID),
+    'sepa_mandates'
+);
 
 $actifMandate  = null;
 $day_of_payment = null;
@@ -36,7 +38,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['iban_nonce']) && isse
     $ibandirty = $_POST['iban'];
     $newIban = str_replace(' ', '', $ibandirty);
 
-    if (create_duplicate_update_IBAN_request($sf_user_ID, $newIban)) {
+    $request_result = create_duplicate_update_IBAN_request($sf_user_ID, $newIban);
+
+    if (is_wp_error($request_result)) {
+        aif_salesforce_service_unavailable($request_result);
+    }
+
+    if (is_object($request_result) && !empty($request_result->success)) {
         $success_message_title = 'Votre demande de modification a bien été prise en compte';
 
         $url = get_permalink(get_page_by_path('mes-demandes'));

--- a/wp-content/themes/humanity-theme/page-verifier-votre-email.php
+++ b/wp-content/themes/humanity-theme/page-verifier-votre-email.php
@@ -53,9 +53,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['form_action']) && $_P
     if ($turnstile_error !== null) {
         $send_code_error_message = turnstile_friendly_error($turnstile_error);
     } else {
-        $sf_user = get_salesforce_member_data($email);
+        $sf_user = aif_validate_salesforce_member(get_salesforce_member_data($email));
 
-        if ($sf_user && has_access_to_donation_space($sf_user)) {
+        if (is_wp_error($sf_user)) {
+            aif_log_salesforce_error($sf_user);
+            $send_code_error_message = AIF_SALESFORCE_SERVICE_UNAVAILABLE_MESSAGE;
+        } elseif (has_access_to_donation_space($sf_user)) {
             $stored_user = get_user_by('email', $email);
 
             if (!$stored_user) {

--- a/wp-content/themes/humanity-theme/patterns/contact-us.php
+++ b/wp-content/themes/humanity-theme/patterns/contact-us.php
@@ -12,10 +12,10 @@ if (!headers_sent()) {
     header('Pragma: no-cache');
 }
 
-$current_user = wp_get_current_user();
-$sf_user_ID = get_SF_user_ID($current_user->ID);
+$sf_member = aif_get_request_salesforce_member();
+$sf_user_ID = $sf_member->Id;
 
-$SF_User = get_salesforce_user_data($sf_user_ID);
+$SF_User = aif_require_salesforce_object(get_salesforce_user_data($sf_user_ID), 'contact', 'Id');
 
 $subject = '';
 
@@ -31,7 +31,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' &&  isset($_POST['subject']) && isset(
     $message = sanitize_text_field($_POST['message']);
     $subject = sanitize_text_field($_POST['subject']);
 
-    if (create_contact_request($sf_user_ID, $message, $subject, $SF_User->Tech_Lien_Mandat_Actif__c)) {
+    $request_result = create_contact_request($sf_user_ID, $message, $subject, $SF_User->Tech_Lien_Mandat_Actif__c);
+
+    if (is_wp_error($request_result)) {
+        aif_salesforce_service_unavailable($request_result);
+    }
+
+    if (is_object($request_result) && !empty($request_result->success)) {
         $success_message_title = 'Votre demande de contact à bien été prise en compte';
         $url = get_permalink(get_page_by_path('mes-demandes'));
         $success_message = "Vous pouvez voir le suivi du traitement de vos demandes sur la page  <a class='aif-link--secondary' href='{$url}'> Mes demandes. </a>";

--- a/wp-content/themes/humanity-theme/patterns/my-space-sidebar.php
+++ b/wp-content/themes/humanity-theme/patterns/my-space-sidebar.php
@@ -31,12 +31,10 @@
     $is_member = false;
 
 if (is_user_logged_in()) {
-    $current_user = wp_get_current_user();
+    if (function_exists('aif_get_request_salesforce_member')) {
+        $sf_member = aif_get_request_salesforce_member();
 
-    if (function_exists('get_salesforce_member_data')) {
-        $sf_member = get_salesforce_member_data($current_user->user_email);
-
-        if (isset($sf_member) && !empty($sf_member->isMembre)) {
+        if (is_object($sf_member) && !empty($sf_member->isMembre)) {
             $is_member = true;
         }
     }

--- a/wp-content/themes/humanity-theme/patterns/my-space-sidebar.php
+++ b/wp-content/themes/humanity-theme/patterns/my-space-sidebar.php
@@ -31,12 +31,10 @@
     $is_member = false;
 
 if (is_user_logged_in()) {
-    if (function_exists('aif_get_request_salesforce_member')) {
-        $sf_member = aif_get_request_salesforce_member();
+    $sf_member = get_query_var('aif_salesforce_member', null);
 
-        if (is_object($sf_member) && !empty($sf_member->isMembre)) {
-            $is_member = true;
-        }
+    if (is_object($sf_member) && !empty($sf_member->isMembre)) {
+        $is_member = true;
     }
 }
 


### PR DESCRIPTION
## Contexte

Lors d’un timeout ou d’une réponse Salesforce invalide, les fonctions d’accès pouvaient retourner implicitement null. Les appelants lisaient ensuite des propriétés sur ce résultat et déclenchaient des erreurs en cascade. Plusieurs recherches identiques du membre pouvaient aussi être effectuées pendant une même requête WordPress.

## Modifications

- retourne des WP_Error explicites pour les erreurs OAuth, réseau, HTTP et JSON ;
- journalise un contexte technique exploitable sans email, token ni corps sensible ;
- prépare et partage le membre Salesforce une seule fois dans le contexte de la requête ;
- distingue un Contact absent d’une indisponibilité Salesforce et affiche alors une réponse 503 ;
- empêche les appels dépendants lorsqu’une recherche Salesforce échoue ou qu’un identifiant manque ;
- adapte les pages, contrôles d’accès, composants et endpoints concernés ;
- ajoute les tests unitaires couvrant les erreurs et la réutilisation du contexte préparé.

## Validation

- vendor/bin/phpunit --no-output
- composer run cs
- composer run analyse -- --no-progress --error-format=table
- git diff --check

Ticket : MAINT-302