### PR TITLE
PROD - fix(forms): enforce Turnstile on public submissions

### DIFF
--- a/private/src/scripts/modules/turnstile.js
+++ b/private/src/scripts/modules/turnstile.js
@@ -184,14 +184,15 @@ const resubmit = (form, submitter) => {
 };
 
 /**
- * Polls briefly for Cloudflare's hidden response input after a user submits early.
+ * Polls for Cloudflare's hidden response input after a user submits early.
+ * Turnstile's callbacks own success and failure; the client must not guess that
+ * a visitor interaction failed after an arbitrary short delay.
  *
  * @param {HTMLFormElement} form Pending form.
  * @param {Submitter|null} submitter Submitter to preserve on resubmit.
- * @param {number} attempts Remaining polling attempts.
  * @returns {void}
  */
-const waitForResponse = (form, submitter, attempts) => {
+const waitForResponse = (form, submitter) => {
   if (!pendingForms.has(form)) return;
 
   if (getResponse(form)) {
@@ -199,15 +200,8 @@ const waitForResponse = (form, submitter, attempts) => {
     return;
   }
 
-  if (attempts <= 0) {
-    pendingForms.delete(form);
-    setSubmitting(submitter, false);
-    showMessage(form, FAILURE_MESSAGE);
-    return;
-  }
-
   window.setTimeout(() => {
-    waitForResponse(form, submitter, attempts - 1);
+    waitForResponse(form, submitter);
   }, 250);
 };
 
@@ -225,6 +219,7 @@ const submitWhenVerified = (event) => {
   }
 
   event.preventDefault();
+  event.stopPropagation();
 
   if (pendingForms.has(form)) return;
 
@@ -236,7 +231,7 @@ const submitWhenVerified = (event) => {
   pendingForms.add(form);
   setSubmitting(submitter, true);
   showMessage(form, VERIFYING_MESSAGE);
-  waitForResponse(form, submitter, 12);
+  waitForResponse(form, submitter);
 };
 
 /**

--- a/private/tests/e2e/.wp-env.e2e.json
+++ b/private/tests/e2e/.wp-env.e2e.json
@@ -6,6 +6,7 @@
     "amnestywebsite/cmb2-message-field",
     "amnestywebsite/cmb2-password-field",
     "jaymcp/cmb2-field-order",
+    "../wp-content/plugins/aif-donor-space",
     "https://downloads.wordpress.org/plugin/jetpack.15.8.zip",
     "./tests/e2e/wordpress/aif-e2e-support"
   ],

--- a/private/tests/e2e/business-form-turnstile.spec.mjs
+++ b/private/tests/e2e/business-form-turnstile.spec.mjs
@@ -1,0 +1,84 @@
+import { expect, test, uniqueEmail } from './support/fixtures';
+import { getClhState, setupBusinessFormFixtures } from './support/business-forms';
+import { getSalesforceCalls, resetSalesforceCalls } from './support/salesforce';
+import { mockSuccessfulTurnstile, setServerSideTurnstileResult } from './support/turnstile';
+
+test.describe('non-Jetpack business forms rejected by server-side Turnstile', () => {
+  let fixtures;
+
+  test.beforeEach(async ({ request, salesforceTestId }) => {
+    fixtures = await setupBusinessFormFixtures(request, salesforceTestId);
+    expect(fixtures.ready).toBe(true);
+    await resetSalesforceCalls(request, salesforceTestId);
+  });
+
+  test('does not call Salesforce for a rejected Chronicle request', async ({
+    page,
+    request,
+    gotoWithoutCookieOverlay,
+    salesforceTestId,
+  }) => {
+    await mockSuccessfulTurnstile(page, { token: 'mock-chronicle-rejected-token' });
+    await gotoWithoutCookieOverlay(fixtures.chronicle_path);
+
+    const form = '#discover-chronicle-form';
+    await setServerSideTurnstileResult(page, form, { success: false });
+    await page.locator('#lastname').fill('Lovelace');
+    await page.locator('#firstname').fill('Ada');
+    await page.locator('#street-address').fill('1 rue des Droits humains');
+    await page.locator('#zipcode').fill('75001');
+    await page.locator('#city').fill('Paris');
+    await page.locator('#email').fill(uniqueEmail());
+    await page.getByRole('button', { name: 'Envoyer ma demande' }).click();
+
+    await expect(page.getByText('La vérification de sécurité a échoué')).toBeVisible();
+    await expect(page).not.toHaveURL(/inscription_chronique=success/);
+    await expect.poll(() => getSalesforceCalls(request, salesforceTestId)).toEqual([]);
+  });
+
+  test('does not search for a donor after a rejected e-mail check', async ({
+    page,
+    request,
+    gotoWithoutCookieOverlay,
+    salesforceTestId,
+  }) => {
+    await mockSuccessfulTurnstile(page, { token: 'mock-donor-rejected-token' });
+    await gotoWithoutCookieOverlay(fixtures.donor_path);
+
+    const form = 'form.aif-form-container';
+    await setServerSideTurnstileResult(page, form, { success: false });
+    await page.locator('input[name="email"]').fill(uniqueEmail());
+    await page.getByRole('button', { name: 'Rechercher' }).click();
+
+    await expect(page.getByText('La vérification de sécurité a échoué')).toBeVisible();
+    await expect.poll(() => getSalesforceCalls(request, salesforceTestId)).toEqual([]);
+  });
+
+  test('does not mutate the CLH skipped-petition state after a rejected skip', async ({
+    context,
+    page,
+    gotoWithoutCookieOverlay,
+  }) => {
+    await mockSuccessfulTurnstile(page, { token: 'mock-clh-skip-rejected-token' });
+    await gotoWithoutCookieOverlay(fixtures.tunnel_path);
+
+    const form = 'form.tunnel-clh-skip-form';
+    await expect(page.locator(form)).toHaveCount(1);
+    const petitionId = Number(await page.locator(`${form} input[name="petition_id"]`).inputValue());
+    expect(petitionId).toBe(fixtures.petition_id);
+
+    const stateBefore = await getClhState(page);
+    expect(stateBefore.skipped_petitions).not.toContain(petitionId);
+    await setServerSideTurnstileResult(page, form, { success: false });
+    await page.locator('button[name="skip_petition"]:visible').click();
+
+    await expect(page).toHaveURL(/signature_status=turnstile/);
+    await expect(page.getByText('La vérification de sécurité a échoué')).toBeVisible();
+    await expect.poll(() => getClhState(page)).toEqual(stateBefore);
+
+    const skippedCookie = (await context.cookies()).find(
+      (cookie) => cookie.name === 'clh_skipped_petitions',
+    );
+    expect(skippedCookie).toBeUndefined();
+  });
+});

--- a/private/tests/e2e/foundation-form.spec.mjs
+++ b/private/tests/e2e/foundation-form.spec.mjs
@@ -1,4 +1,10 @@
 import { expect, test } from './support/fixtures';
+import {
+  TEST_SITE_KEY,
+  mockSuccessfulTurnstile,
+  setServerSideTurnstileResult,
+} from './support/turnstile';
+import { getJetpackEffects, resetJetpackEffects } from './support/jetpack-effects';
 
 const FONDATION_PATH = '/fondation/';
 
@@ -11,9 +17,15 @@ test.describe('foundation contact form', () => {
     page,
     gotoWithoutCookieOverlay,
   }) => {
+    await mockSuccessfulTurnstile(page);
     await gotoWithoutCookieOverlay(FONDATION_PATH);
 
     const form = page.locator('div[data-test="contact-form"]');
+    await expect(form.locator('.cf-turnstile')).toHaveAttribute('data-sitekey', TEST_SITE_KEY);
+    await expect(form.locator('.cf-turnstile')).toHaveAttribute(
+      'data-appearance',
+      'interaction-only',
+    );
     await expect(form.getByLabel(/^Nom/)).toBeVisible();
     await expect(form.getByLabel('Prénom')).toBeVisible();
     await expect(form.getByLabel('E-mail')).toBeVisible();
@@ -26,9 +38,13 @@ test.describe('foundation contact form', () => {
     page,
     gotoWithoutCookieOverlay,
   }) => {
+    await mockSuccessfulTurnstile(page);
     await gotoWithoutCookieOverlay(FONDATION_PATH);
 
     const form = page.locator('div[data-test="contact-form"]');
+    await setServerSideTurnstileResult(page, 'div[data-test="contact-form"] form', {
+      success: true,
+    });
     await form.getByLabel('Monsieur', { exact: true }).check();
     await form.getByLabel(/^Nom/).fill('Turing');
     await form.getByLabel('Prénom').fill('Alan');
@@ -45,11 +61,18 @@ test.describe('foundation contact form', () => {
 
   test('submits with only the required fields and shows the real Jetpack success message', async ({
     page,
+    request,
+    salesforceTestId: e2eTestId,
     gotoWithoutCookieOverlay,
   }) => {
+    await mockSuccessfulTurnstile(page);
+    await resetJetpackEffects(request, e2eTestId);
     await gotoWithoutCookieOverlay(FONDATION_PATH);
 
     const form = page.locator('div[data-test="contact-form"]');
+    await setServerSideTurnstileResult(page, 'div[data-test="contact-form"] form', {
+      success: true,
+    });
     await form.getByLabel(/^Nom/).fill('Turing');
     await form.getByLabel('Prénom').fill('Alan');
     await form.getByLabel('E-mail').fill('alan@example.test');
@@ -57,5 +80,83 @@ test.describe('foundation contact form', () => {
     await form.getByRole('button', { name: 'Envoyer' }).click();
 
     await expect(page.getByText('Merci pour votre réponse')).toBeVisible();
+    await expect
+      .poll(() => getJetpackEffects(request, e2eTestId))
+      .toEqual({
+        feedback_count: 1,
+        mail_count: 1,
+      });
+  });
+
+  test('waits for an interaction-only Turnstile token before submitting', async ({
+    page,
+    gotoWithoutCookieOverlay,
+  }) => {
+    const jetpackPosts = [];
+    page.on('request', (request) => {
+      const url = new URL(request.url());
+
+      if (
+        request.method() === 'POST' &&
+        url.pathname.endsWith('/wp-admin/admin-ajax.php') &&
+        url.searchParams.get('action') === 'grunion-contact-form'
+      ) {
+        jetpackPosts.push(request);
+      }
+    });
+    await mockSuccessfulTurnstile(page, {
+      delay: 5000,
+      token: 'mock-jetpack-interaction-token',
+      trigger: 'submit',
+    });
+    await gotoWithoutCookieOverlay(FONDATION_PATH);
+
+    const form = page.locator('div[data-test="contact-form"]');
+    await setServerSideTurnstileResult(page, 'div[data-test="contact-form"] form', {
+      success: true,
+    });
+    await form.getByLabel(/^Nom/).fill('Turing');
+    await form.getByLabel('Prénom').fill('Alan');
+    await form.getByLabel('E-mail').fill('alan@example.test');
+
+    const submitter = form.getByRole('button', { name: 'Envoyer' });
+    await submitter.click();
+
+    await expect(form.locator('[data-turnstile-client-error]')).toContainText(
+      'vérification de sécurité est en cours',
+    );
+    await expect(submitter).toBeDisabled();
+    await expect(submitter).toHaveAttribute('aria-busy', 'true');
+    await page.waitForTimeout(1000);
+    expect(jetpackPosts).toHaveLength(0);
+
+    await expect(page.getByText('Merci pour votre réponse')).toBeVisible();
+    expect(jetpackPosts).toHaveLength(1);
+  });
+
+  test('does not save feedback, send mail, or confirm a submission rejected by server-side Turnstile', async ({
+    page,
+    request,
+    salesforceTestId: e2eTestId,
+    gotoWithoutCookieOverlay,
+  }) => {
+    await mockSuccessfulTurnstile(page);
+    await resetJetpackEffects(request, e2eTestId);
+    const effectsBeforeSubmission = await getJetpackEffects(request, e2eTestId);
+    await gotoWithoutCookieOverlay(FONDATION_PATH);
+
+    const form = page.locator('div[data-test="contact-form"]');
+    await setServerSideTurnstileResult(page, 'div[data-test="contact-form"] form', {
+      success: false,
+    });
+    await form.getByLabel(/^Nom/).fill('Turing');
+    await form.getByLabel('Prénom').fill('Alan');
+    await form.getByLabel('E-mail').fill('alan@example.test');
+
+    await form.getByRole('button', { name: 'Envoyer' }).click();
+
+    await expect(page.getByText(/La vérification de sécurité a échoué/)).toBeVisible();
+    await expect(page.getByText('Merci pour votre réponse')).not.toBeVisible();
+    await expect.poll(() => getJetpackEffects(request, e2eTestId)).toEqual(effectsBeforeSubmission);
   });
 });

--- a/private/tests/e2e/legacy-giving-form.spec.mjs
+++ b/private/tests/e2e/legacy-giving-form.spec.mjs
@@ -1,4 +1,5 @@
 import { expect, test } from './support/fixtures';
+import { mockSuccessfulTurnstile, setServerSideTurnstileResult } from './support/turnstile';
 
 const LEGS_PATH = '/legs/';
 
@@ -23,6 +24,9 @@ const fillRequiredFields = async (form) => {
 };
 
 test.describe('legacy giving (legs) brochure request', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSuccessfulTurnstile(page);
+  });
   test('reveals the brochure request form from the sticky call-to-action', async ({
     page,
     gotoWithoutCookieOverlay,
@@ -69,6 +73,9 @@ test.describe('legacy giving (legs) brochure request', () => {
 
     const form = page.locator('#legs-form');
     await fillRequiredFields(form);
+    await setServerSideTurnstileResult(page, '#legs-form form', {
+      success: true,
+    });
 
     await form.getByRole('button', { name: 'Envoyer' }).click();
 

--- a/private/tests/e2e/support/business-forms.mjs
+++ b/private/tests/e2e/support/business-forms.mjs
@@ -1,0 +1,16 @@
+const BUSINESS_FORM_FIXTURES_ENDPOINT = '/wp-json/aif-e2e/v1/business-form-fixtures';
+const CLH_STATE_ENDPOINT = '/wp-json/aif-e2e/v1/clh-state';
+
+export const setupBusinessFormFixtures = async (request, testId) => {
+  const response = await request.post(BUSINESS_FORM_FIXTURES_ENDPOINT, {
+    headers: { 'X-AIF-E2E-Test-Id': testId },
+  });
+
+  return response.json();
+};
+
+export const getClhState = async (page) =>
+  page.evaluate(async (endpoint) => {
+    const response = await fetch(endpoint);
+    return response.json();
+  }, CLH_STATE_ENDPOINT);

--- a/private/tests/e2e/support/jetpack-effects.mjs
+++ b/private/tests/e2e/support/jetpack-effects.mjs
@@ -1,0 +1,15 @@
+const JETPACK_EFFECTS_ENDPOINT = '/wp-json/aif-e2e/v1/jetpack-effects';
+
+export const resetJetpackEffects = async (request, testId) => {
+  await request.delete(JETPACK_EFFECTS_ENDPOINT, {
+    headers: { 'X-AIF-E2E-Test-Id': testId },
+  });
+};
+
+export const getJetpackEffects = async (request, testId) => {
+  const response = await request.get(JETPACK_EFFECTS_ENDPOINT, {
+    headers: { 'X-AIF-E2E-Test-Id': testId },
+  });
+
+  return response.json();
+};

--- a/private/tests/e2e/support/turnstile.mjs
+++ b/private/tests/e2e/support/turnstile.mjs
@@ -55,9 +55,14 @@ const mockScript = ({ mode, delay, token, trigger }) => `
           return;
         }
 
-        form.addEventListener('submit', () => {
+        const onSubmit = (event) => {
+          if (event.target !== form) return;
+
+          document.removeEventListener('submit', onSubmit, true);
           window.setTimeout(() => resolve(widget), delay);
-        }, { capture: true, once: true });
+        };
+
+        document.addEventListener('submit', onSubmit, true);
         return;
       }
 

--- a/private/tests/e2e/turnstile-guard.spec.mjs
+++ b/private/tests/e2e/turnstile-guard.spec.mjs
@@ -124,7 +124,7 @@ test('shows a failure message when Turnstile reports an error and does not submi
   expect(posts).toHaveLength(0);
 });
 
-test('shows a failure message when Turnstile never creates a token', async ({
+test('keeps waiting while Turnstile has not reported success or failure', async ({
   page,
   gotoWithoutCookieOverlay,
 }) => {
@@ -136,9 +136,8 @@ test('shows a failure message when Turnstile never creates a token', async ({
   await page.locator('#submit-btn').click();
 
   await expect(page.getByRole('alert')).toContainText('La vérification de sécurité est en cours');
-  await expect(page.getByRole('alert')).toContainText(
-    'La vérification de sécurité n’a pas pu être effectuée',
-    { timeout: 5000 },
-  );
+  await page.waitForTimeout(3500);
+  await expect(page.getByRole('alert')).toContainText('La vérification de sécurité est en cours');
+  await expect(page.locator('#submit-btn')).toBeDisabled();
   expect(posts).toHaveLength(0);
 });

--- a/private/tests/e2e/wordpress/aif-e2e-support/aif-e2e-support.php
+++ b/private/tests/e2e/wordpress/aif-e2e-support/aif-e2e-support.php
@@ -62,7 +62,13 @@ if (!function_exists('the_field')) {
     }
 }
 
-if (!function_exists('aif_include_partial')) {
+add_action('plugins_loaded', function () {
+    $donor_partial_helper = WP_PLUGIN_DIR . '/aif-donor-space/includes/utils.php';
+
+    if (function_exists('aif_include_partial') || is_file($donor_partial_helper)) {
+        return;
+    }
+
     function aif_include_partial(string $name, array $args = []): void
     {
         if ('alert' !== $name) {
@@ -79,7 +85,7 @@ if (!function_exists('aif_include_partial')) {
             wp_kses_post($content)
         );
     }
-}
+});
 
 /**
  * Shared shape for every faked pre_http_request response below (Turnstile and
@@ -148,6 +154,174 @@ function aif_e2e_salesforce_calls_option_name(): string
     return 'aif_e2e_salesforce_calls_' . aif_e2e_get_test_id();
 }
 
+function aif_e2e_jetpack_effects_option_name(): string
+{
+    return 'aif_e2e_jetpack_effects_' . aif_e2e_get_test_id();
+}
+
+function aif_e2e_get_jetpack_effects(): array
+{
+    $effects = get_option(aif_e2e_jetpack_effects_option_name(), []);
+
+    return [
+        'feedback_count' => (int) ($effects['feedback_count'] ?? 0),
+        'mail_count' => (int) ($effects['mail_count'] ?? 0),
+    ];
+}
+
+function aif_e2e_upsert_page(string $slug, string $title, int $parent_id = 0, string $content = ''): int
+{
+    $path = $parent_id ? get_page_uri($parent_id) . '/' . $slug : $slug;
+    $page = get_page_by_path($path, OBJECT, 'page');
+
+    if ($page instanceof WP_Post) {
+        return (int) $page->ID;
+    }
+
+    $page_data = [
+        'post_title' => $title,
+        'post_name' => $slug,
+        'post_content' => $content,
+        'post_status' => 'publish',
+        'post_type' => 'page',
+        'post_parent' => $parent_id,
+    ];
+
+    $page_id = wp_insert_post($page_data, true);
+
+    return is_wp_error($page_id) ? 0 : (int) $page_id;
+}
+
+function aif_e2e_upsert_clh_petition(): ?WP_Post
+{
+    $petition = get_page_by_path('aif-e2e-clh-petition', OBJECT, 'petition');
+
+    if (!$petition instanceof WP_Post) {
+        global $wpdb;
+
+        $now = current_time('mysql');
+        $now_gmt = current_time('mysql', true);
+        $inserted = $wpdb->insert($wpdb->posts, [
+            'post_author' => 1,
+            'post_date' => $now,
+            'post_date_gmt' => $now_gmt,
+            'post_content' => '',
+            'post_title' => 'Pétition CLH (e2e)',
+            'post_excerpt' => 'Pétition dédiée au scénario de skip CLH.',
+            'post_status' => 'publish',
+            'comment_status' => 'closed',
+            'ping_status' => 'closed',
+            'post_password' => '',
+            'post_name' => 'aif-e2e-clh-petition',
+            'to_ping' => '',
+            'pinged' => '',
+            'post_modified' => $now,
+            'post_modified_gmt' => $now_gmt,
+            'post_content_filtered' => '',
+            'post_parent' => 0,
+            'guid' => home_url('/petitions/aif-e2e-clh-petition/'),
+            'menu_order' => 0,
+            'post_type' => 'petition',
+            'post_mime_type' => '',
+            'comment_count' => 0,
+        ]);
+
+        if (false === $inserted) {
+            return null;
+        }
+
+        clean_post_cache((int) $wpdb->insert_id);
+        $petition = get_post((int) $wpdb->insert_id);
+    }
+
+    if (!$petition instanceof WP_Post) {
+        return null;
+    }
+
+    update_post_meta($petition->ID, 'type', 'petition');
+    update_post_meta($petition->ID, 'date_de_fin', gmdate('Y-m-d', strtotime('+1 year')));
+    update_post_meta($petition->ID, 'objectif_signatures', 1000);
+    update_post_meta($petition->ID, 'clh_petition', '1');
+
+    return $petition;
+}
+
+function aif_e2e_setup_business_form_fixtures(): array
+{
+    global $wpdb;
+
+    $lock_name = 'aif_e2e_business_form_fixtures';
+    $wpdb->get_var($wpdb->prepare('SELECT GET_LOCK(%s, 10)', $lock_name));
+
+    try {
+        $chronicle_page_id = aif_e2e_upsert_page(
+            'aif-e2e-discover-chronicle',
+            'Découvrir la Chronique (e2e)',
+            0,
+            '<!-- wp:pattern {"slug":"amnesty/page-discover-chronicle-content"} /-->'
+        );
+        $donor_page_id = aif_e2e_upsert_page('aif-e2e-check-email', 'Contrôle e-mail donateur (e2e)');
+
+        $about_page_id = aif_e2e_upsert_page('nous-connaitre', 'Nous connaître');
+        $campaigns_page_id = aif_e2e_upsert_page('nos-combats', 'Nos combats', $about_page_id);
+        $clh_page_id = aif_e2e_upsert_page('changez-leur-histoire', 'Changez leur histoire', $campaigns_page_id);
+        $tunnel_page_id = aif_e2e_upsert_page(
+            'campagne',
+            'Campagne Changez leur histoire (e2e)',
+            $clh_page_id,
+            '<!-- wp:pattern {"slug":"amnesty/page-tunnel-clh-content"} /-->'
+        );
+
+        update_post_meta($clh_page_id, 'highlight_clh', '1');
+        update_post_meta($clh_page_id, 'start_date_highligth_clh', gmdate('Y-m-d H:i:s', strtotime('-1 day')));
+        update_post_meta($clh_page_id, 'end_date_highlight_clh', gmdate('Y-m-d H:i:s', strtotime('+1 year')));
+
+        $standard_petition = get_page_by_path('aif-e2e-petition', OBJECT, 'petition');
+        if ($standard_petition instanceof WP_Post) {
+            delete_post_meta($standard_petition->ID, 'clh_petition');
+        }
+        $petition = aif_e2e_upsert_clh_petition();
+
+        return [
+            'chronicle_path' => '/aif-e2e-discover-chronicle/',
+            'donor_path' => '/aif-e2e-check-email/',
+            'tunnel_path' => '/nous-connaitre/nos-combats/changez-leur-histoire/campagne/',
+            'petition_id' => $petition instanceof WP_Post ? (int) $petition->ID : 0,
+            'ready' => $chronicle_page_id > 0 && $donor_page_id > 0 && $tunnel_page_id > 0 && $petition instanceof WP_Post,
+        ];
+    } finally {
+        $wpdb->get_var($wpdb->prepare('SELECT RELEASE_LOCK(%s)', $lock_name));
+    }
+}
+
+add_filter('template_include', function ($template) {
+    if (!is_page('aif-e2e-check-email')) {
+        return $template;
+    }
+
+    $donor_template = WP_PLUGIN_DIR . '/aif-donor-space/templates/check-email.php';
+
+    return is_file($donor_template) ? $donor_template : $template;
+}, PHP_INT_MAX);
+
+add_action('wp_insert_post', function ($post_id, $post, $update) {
+    if ($update || !$post instanceof WP_Post || 'feedback' !== $post->post_type) {
+        return;
+    }
+
+    $effects = aif_e2e_get_jetpack_effects();
+    ++$effects['feedback_count'];
+    update_option(aif_e2e_jetpack_effects_option_name(), $effects, false);
+}, 10, 3);
+
+add_filter('pre_wp_mail', function ($return, $atts) {
+    $effects = aif_e2e_get_jetpack_effects();
+    ++$effects['mail_count'];
+    update_option(aif_e2e_jetpack_effects_option_name(), $effects, false);
+
+    return $return;
+}, 10, 2);
+
 /**
  * Mocks every outbound Salesforce call (includes/salesforce/data.php +
  * authentification.php always go through AIF_SALESFORCE_URL) and records
@@ -212,6 +386,45 @@ add_action('rest_api_init', function () {
         'callback' => function () {
             delete_option(aif_e2e_salesforce_calls_option_name());
             return new WP_REST_Response(['cleared' => true], 200);
+        },
+        'permission_callback' => '__return_true',
+    ]);
+
+    register_rest_route('aif-e2e/v1', '/jetpack-effects', [
+        'methods' => 'GET',
+        'callback' => function () {
+            return new WP_REST_Response(aif_e2e_get_jetpack_effects(), 200);
+        },
+        'permission_callback' => '__return_true',
+    ]);
+
+    register_rest_route('aif-e2e/v1', '/jetpack-effects', [
+        'methods' => 'DELETE',
+        'callback' => function () {
+            delete_option(aif_e2e_jetpack_effects_option_name());
+            return new WP_REST_Response(['cleared' => true], 200);
+        },
+        'permission_callback' => '__return_true',
+    ]);
+
+    register_rest_route('aif-e2e/v1', '/business-form-fixtures', [
+        'methods' => 'POST',
+        'callback' => function () {
+            return new WP_REST_Response(aif_e2e_setup_business_form_fixtures(), 200);
+        },
+        'permission_callback' => '__return_true',
+    ]);
+
+    register_rest_route('aif-e2e/v1', '/clh-state', [
+        'methods' => 'GET',
+        'callback' => function () {
+            $skipped_petitions = function_exists('amnesty_get_clh_skipped_petitions')
+                ? amnesty_get_clh_skipped_petitions()
+                : [];
+
+            return new WP_REST_Response([
+                'skipped_petitions' => array_values(array_map('intval', $skipped_petitions)),
+            ], 200);
         },
         'permission_callback' => '__return_true',
     ]);

--- a/private/tests/scripts/modules/turnstile.test.js
+++ b/private/tests/scripts/modules/turnstile.test.js
@@ -52,12 +52,23 @@ describe('turnstile form guard', () => {
     vi.restoreAllMocks();
   });
 
-  it('waits for a Turnstile response before submitting and ignores stale polling ticks', () => {
+  it('waits beyond three seconds for a Turnstile response and ignores stale polling ticks', () => {
     const { form, button } = buildForm();
+    const downstreamSubmit = vi.fn();
+    form.addEventListener('submit', downstreamSubmit);
 
     const event = dispatchSubmit(form, button);
 
     expect(event.defaultPrevented).toBe(true);
+    expect(downstreamSubmit).not.toHaveBeenCalled();
+    expect(button.disabled).toBe(true);
+    expect(form.querySelector('[data-turnstile-client-error]')?.textContent).toContain(
+      'vérification de sécurité est en cours',
+    );
+
+    vi.advanceTimersByTime(3500);
+
+    expect(form.requestSubmit).not.toHaveBeenCalled();
     expect(button.disabled).toBe(true);
     expect(form.querySelector('[data-turnstile-client-error]')?.textContent).toContain(
       'vérification de sécurité est en cours',

--- a/wp-content/plugins/aif-donor-space/templates/check-email.php
+++ b/wp-content/plugins/aif-donor-space/templates/check-email.php
@@ -7,24 +7,26 @@ $success_message = '';
 
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email'])) {
-
-    $email = sanitize_email($_POST['email']);
-
-    if (has_access_to_donation_space($email)) {
-
-        $user = get_user_by('email', $email);
-
-        if ($user) {
-            wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
-            exit;
-        } else {
-            wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
-            exit;
-        }
+    $turnstile_error = verify_turnstile();
+    if ($turnstile_error !== null) {
+        $error_message = turnstile_friendly_error($turnstile_error);
     } else {
-        $error_message = "Vous n'avez pas accès à l'espace don";
-    }
+        $email = sanitize_email($_POST['email']);
 
+        if (has_access_to_donation_space($email)) {
+            $user = get_user_by('email', $email);
+
+            if ($user) {
+                wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
+                exit;
+            } else {
+                wp_redirect(get_permalink(get_page_by_path('connectez-vous')));
+                exit;
+            }
+        } else {
+            $error_message = "Vous n'avez pas accès à l'espace don";
+        }
+    }
 }
 ?>
 
@@ -46,6 +48,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['email'])) {
         <p>Nous avons besoin de votre email pour déterminer si vous êtes déja connu</p>
 
         <form class="aif-form-container" role="form" method="POST" action="">
+            <div
+                class="cf-turnstile"
+                data-callback="aifTurnstileSuccess"
+                data-error-callback="aifTurnstileFailure"
+                data-appearance="interaction-only"
+                data-expired-callback="aifTurnstileFailure"
+                data-timeout-callback="aifTurnstileFailure"
+                data-unsupported-callback="aifTurnstileFailure"
+                data-sitekey="<?php echo esc_attr(aif_turnstile_site_key()); ?>"
+            ></div>
             <label>Votre adresse email</label>
             <div>
                 <input placeholder="adresse@mail.fr" value="" type="email" name="email" required="true">

--- a/wp-content/themes/humanity-theme/includes/jetpack/contact-form.php
+++ b/wp-content/themes/humanity-theme/includes/jetpack/contact-form.php
@@ -1,5 +1,66 @@
 <?php
 
+/**
+ * Add the Turnstile widget to every frontend Jetpack form.
+ *
+ * The filter is applied by Jetpack Forms to both block and shortcode output,
+ * including forms whose content is stored in WordPress rather than in the
+ * theme repository.
+ *
+ * @param string $html The rendered Jetpack form HTML.
+ * @return string The rendered form with a Turnstile widget.
+ */
+function aif_add_turnstile_to_jetpack_form(string $html): string
+{
+    $site_key = aif_turnstile_site_key();
+
+    if (!$site_key || !str_contains($html, '<form')) {
+        return $html;
+    }
+
+    $widget = sprintf(
+        '<div
+            class="cf-turnstile"
+            data-callback="aifTurnstileSuccess"
+            data-error-callback="aifTurnstileFailure"
+            data-appearance="interaction-only"
+            data-expired-callback="aifTurnstileFailure"
+            data-timeout-callback="aifTurnstileFailure"
+            data-unsupported-callback="aifTurnstileFailure"
+            data-sitekey="%s"
+        ></div>',
+        esc_attr($site_key)
+    );
+
+    $form_with_widget = preg_replace('/(<form\b[^>]*>)/i', '$1' . $widget, $html, 1);
+
+    return is_string($form_with_widget) ? $form_with_widget : $html;
+}
+
+add_filter('jetpack_contact_form_html', 'aif_add_turnstile_to_jetpack_form');
+
+/**
+ * Reject Jetpack form submissions before Jetpack saves feedback or sends mail.
+ *
+ * @param bool $is_spam Whether Jetpack already identified the submission as spam.
+ * @return bool|WP_Error Whether to treat the submission as spam or abort it.
+ */
+function aif_reject_jetpack_contact_form_without_turnstile(bool $is_spam): bool|WP_Error
+{
+    $turnstile_error = verify_turnstile();
+
+    if ($turnstile_error === null) {
+        return $is_spam;
+    }
+
+    return new WP_Error(
+        'aif_turnstile_verification_failed',
+        turnstile_friendly_error($turnstile_error)
+    );
+}
+
+add_filter('jetpack_contact_form_is_spam', 'aif_reject_jetpack_contact_form_without_turnstile', 1, 1);
+
 add_filter('wp_mail', function ($args) {
 
     $contact_page = get_page_by_path('contact');

--- a/wp-content/themes/humanity-theme/includes/post-types/petitions.php
+++ b/wp-content/themes/humanity-theme/includes/post-types/petitions.php
@@ -758,6 +758,12 @@ function amnesty_handle_petition_skip(): void
         wp_die('Action non autorisée.', '', ['response' => 403]);
     }
 
+    $turnstile_error = verify_turnstile();
+    if ($turnstile_error !== null) {
+        wp_redirect(add_query_arg('signature_status', 'turnstile', amnesty_get_clh_petition_tunnel_url()));
+        exit;
+    }
+
     $petition_id = absint($_POST['petition_id']);
     if (!$petition_id) {
         wp_redirect(amnesty_get_clh_petition_tunnel_url());

--- a/wp-content/themes/humanity-theme/patterns/page-discover-chronicle-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-discover-chronicle-content.php
@@ -24,49 +24,56 @@ $inscription_chronique_status = $_GET['inscription_chronique'] ?? '';
 $inscription_chronique_success = $inscription_chronique_status === 'success';
 
 if (isset($_POST['sign_discover_chronicle'])) {
-    $themes = isset($_POST['theme']) ? array_map('sanitize_text_field', (array)$_POST['theme']) : [];
-    $discover_chronicle = sanitize_email($_POST['discover-chronicle'] ?? '');
-    $civility = sanitize_text_field($_POST['civility'] ?? '');
-    $lastname = sanitize_text_field($_POST['lastname'] ?? '');
-    $firstname = sanitize_text_field($_POST['firstname'] ?? '');
-    $street_address = sanitize_text_field($_POST['street-address'] ?? '');
-    $address_complement = sanitize_text_field($_POST['address_complement'] ?? '');
-    $address_complement_bis = sanitize_text_field($_POST['address_complement_bis'] ?? '');
-    $zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
-    $city = sanitize_text_field($_POST['city'] ?? '');
-    $country = sanitize_text_field($_POST['country'] ?? '');
-    $email = sanitize_email($_POST['email'] ?? '');
-    $phone = sanitize_text_field($_POST['phone'] ?? '');
+    $turnstile_error = verify_turnstile();
 
-    $form_data = [
-        'Civilite__c' => $civility,
-        'Nom__c' => $lastname,
-        'Prenom__c' => $firstname,
-        'Libelle_de_voie__c' => $street_address,
-        'Complement_adresse__c' => $address_complement,
-        'Lieu_dit__c' => $address_complement_bis,
-        'Code_postal__c' => $zipcode,
-        'Ville__c' => $city,
-        'Pays_Text__c' => $country,
-        'Email__c' => $email,
-        'Telephone__c' => $phone,
-        'Origin' => 'Web',
-        'Type_de_demande_AIF__c' => 'Offre Chronique',
-        'RecordTypeId' => getenv('AIF_SALESFORCE_RECORD_TYPE_ID'),
-        'Code_Marketing_Prestataire__c' => 'WB_CHRONIQUE',
-    ];
+    if ($turnstile_error !== null) {
+        $title = 'Une erreur est survenue';
+        $error_message = turnstile_friendly_error($turnstile_error);
+    } else {
+        $themes = isset($_POST['theme']) ? array_map('sanitize_text_field', (array)$_POST['theme']) : [];
+        $discover_chronicle = sanitize_email($_POST['discover-chronicle'] ?? '');
+        $civility = sanitize_text_field($_POST['civility'] ?? '');
+        $lastname = sanitize_text_field($_POST['lastname'] ?? '');
+        $firstname = sanitize_text_field($_POST['firstname'] ?? '');
+        $street_address = sanitize_text_field($_POST['street-address'] ?? '');
+        $address_complement = sanitize_text_field($_POST['address_complement'] ?? '');
+        $address_complement_bis = sanitize_text_field($_POST['address_complement_bis'] ?? '');
+        $zipcode = sanitize_text_field($_POST['zipcode'] ?? '');
+        $city = sanitize_text_field($_POST['city'] ?? '');
+        $country = sanitize_text_field($_POST['country'] ?? '');
+        $email = sanitize_email($_POST['email'] ?? '');
+        $phone = sanitize_text_field($_POST['phone'] ?? '');
 
-    $find_case_on_sf = get_salesforce_case($email);
-    $existing_case = $find_case_on_sf['totalSize'] > 0;
+        $form_data = [
+            'Civilite__c' => $civility,
+            'Nom__c' => $lastname,
+            'Prenom__c' => $firstname,
+            'Libelle_de_voie__c' => $street_address,
+            'Complement_adresse__c' => $address_complement,
+            'Lieu_dit__c' => $address_complement_bis,
+            'Code_postal__c' => $zipcode,
+            'Ville__c' => $city,
+            'Pays_Text__c' => $country,
+            'Email__c' => $email,
+            'Telephone__c' => $phone,
+            'Origin' => 'Web',
+            'Type_de_demande_AIF__c' => 'Offre Chronique',
+            'RecordTypeId' => getenv('AIF_SALESFORCE_RECORD_TYPE_ID'),
+            'Code_Marketing_Prestataire__c' => 'WB_CHRONIQUE',
+        ];
 
-    if (false === $existing_case) {
-        post_salesforce_case($form_data);
-        wp_redirect(add_query_arg('inscription_chronique', 'success', get_permalink()));
+        $find_case_on_sf = get_salesforce_case($email);
+        $existing_case = $find_case_on_sf['totalSize'] > 0;
+
+        if (false === $existing_case) {
+            post_salesforce_case($form_data);
+            wp_redirect(add_query_arg('inscription_chronique', 'success', get_permalink()));
+            exit;
+        }
+
+        wp_redirect(add_query_arg('inscription_chronique', 'already-sent', get_permalink()));
         exit;
     }
-
-    wp_redirect(add_query_arg('inscription_chronique', 'already-sent', get_permalink()));
-    exit;
 }
 
 ?>
@@ -90,6 +97,25 @@ if (isset($_POST['sign_discover_chronicle'])) {
 		<!-- wp:post-content /-->
 		<div class="discover-chronicle-form-container">
 			<form id="discover-chronicle-form" class="discover-chronicle-form" action="" method="post">
+				<div
+					class="cf-turnstile"
+					data-callback="aifTurnstileSuccess"
+					data-error-callback="aifTurnstileFailure"
+					data-appearance="interaction-only"
+					data-expired-callback="aifTurnstileFailure"
+					data-timeout-callback="aifTurnstileFailure"
+					data-unsupported-callback="aifTurnstileFailure"
+					data-sitekey="<?php echo esc_attr(aif_turnstile_site_key()); ?>"
+				></div>
+				<?php if (!empty($error_message)) : ?>
+					<?php
+                    aif_include_partial('alert', [
+                        'state' => 'error',
+                        'title' => $title,
+                        'content' => $error_message,
+                    ]);
+				    ?>
+				<?php endif; ?>
 				<div class="form-mess hidden"></div>
 				<div class="form-group civility">
 					<label class="civility-label">Civilité :</label>
@@ -167,17 +193,17 @@ if (isset($_POST['sign_discover_chronicle'])) {
 						<select class="country-input " name="country">
 							<option value=""><?php _e('Pays*', 'textdomain'); ?></option>
 							<?php
-                            foreach ($countries as $country) :
-                                $country_name = get_the_title($country->ID);
-                                ?>
+				            foreach ($countries as $country) :
+				                $country_name = get_the_title($country->ID);
+				                ?>
 								<option value="<?php echo esc_attr($country_name); ?>"
 									<?php
-                                    if (esc_attr($country_name) === 'France') :
-                                        ?>
+				                    if (esc_attr($country_name) === 'France') :
+				                        ?>
 										selected="selected"
 									<?php
-                                    endif;
-                                ?>
+				                    endif;
+				                ?>
 								>
 									<?php echo esc_html(ucwords(strtolower($country_name))); ?>
 								</option>

--- a/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
+++ b/wp-content/themes/humanity-theme/patterns/page-tunnel-clh-content.php
@@ -336,6 +336,16 @@ $turnstile_error_message = $GLOBALS['petition_turnstile_error_message'] ?? '';
 							</div>
 							<form id="<?php echo esc_attr($skip_form_id); ?>" class="tunnel-clh-skip-form" method="post"
 							      action="">
+								<div
+									class="cf-turnstile"
+									data-callback="aifTurnstileSuccess"
+									data-error-callback="aifTurnstileFailure"
+									data-appearance="interaction-only"
+									data-expired-callback="aifTurnstileFailure"
+									data-timeout-callback="aifTurnstileFailure"
+									data-unsupported-callback="aifTurnstileFailure"
+									data-sitekey="<?= esc_attr(getenv('TURNSTILE_SITE_KEY')); ?>"
+								></div>
 								<?php wp_nonce_field('clh_skip_petition', 'clh_skip_nonce'); ?>
 								<input type="hidden" name="petition_id"
 								       value="<?= esc_attr((string)$next_petition['id']); ?>">


### PR DESCRIPTION
# Why

Public Jetpack and business forms could accept automated submissions because Turnstile was missing or was not verified before mail, persistence, and business effects.

# What changed

- protect Jetpack, Chronique, donor e-mail, and CLH skip submissions with interaction-only Turnstile and server-side validation
- keep early submissions pending until Cloudflare succeeds or fails without allowing a tokenless Jetpack request
- add E2E coverage proving rejected submissions do not send mail, save feedback, call Salesforce, or mutate CLH state

(cherry picked from commit 232f72dafae107c9ae3cecf9e5ee23b860606fbd)