### PR TITLE
fix(media): décale la conversion AVIF/WebP en tâche asynchrone

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,6 +1,7 @@
 [
   "0 0 * * * $ROOT/infogerance/backup-wp.sh",
   "0 0 * * * wp sync compteurs",
+  "*/5 * * * * wp amnesty media process-modern-queue --limit=20 --time-limit=45",
   "*/15 * * * * wp sync signatures",
   "30 23 * * * wp sync signatures_failed"
 ]

--- a/tests/Media/ModernImagesTest.php
+++ b/tests/Media/ModernImagesTest.php
@@ -274,6 +274,7 @@ final class ModernImagesTest extends TestCase
         self::assertNotNull($webp);
         $webpFile = $this->tmpDir . '/2026/07/source.webp';
         touch($webpFile, time() - 100);
+        clearstatcache(true, $webpFile);
         $mtime = filemtime($webpFile);
 
         $taskKey = amnesty_modern_image_task_key('2026/07/source.jpg', 'image/webp');
@@ -288,6 +289,7 @@ final class ModernImagesTest extends TestCase
 
         $stats = amnesty_process_modern_image_queue_for_attachment(32);
         $stored = wp_get_attachment_metadata(32);
+        clearstatcache(true, $webpFile);
 
         self::assertSame(1, $stats['processed']);
         self::assertSame(1, $stats['updated']);

--- a/tests/Media/ModernImagesTest.php
+++ b/tests/Media/ModernImagesTest.php
@@ -39,10 +39,54 @@ if (!function_exists('wp_get_attachment_metadata')) {
     }
 }
 
+if (!function_exists('wp_update_attachment_metadata')) {
+    function wp_update_attachment_metadata(int $attachment_id, array $metadata): bool
+    {
+        if (!empty($GLOBALS['__phpunit_fail_attachment_metadata_update'])) {
+            return false;
+        }
+
+        $GLOBALS['__phpunit_attachment_metadata'][$attachment_id] = $metadata;
+
+        return true;
+    }
+}
+
 if (!function_exists('wp_get_upload_dir')) {
     function wp_get_upload_dir(): array
     {
         return $GLOBALS['__phpunit_upload_dir'];
+    }
+}
+
+if (!function_exists('get_post_meta')) {
+    function get_post_meta(int $post_id, string $key = '', bool $single = false): mixed
+    {
+        if ('' === $key) {
+            return $GLOBALS['__phpunit_post_meta'][$post_id] ?? [];
+        }
+
+        $value = $GLOBALS['__phpunit_post_meta'][$post_id][$key] ?? '';
+
+        return $single ? $value : [$value];
+    }
+}
+
+if (!function_exists('update_post_meta')) {
+    function update_post_meta(int $post_id, string $key, mixed $value): bool
+    {
+        $GLOBALS['__phpunit_post_meta'][$post_id][$key] = $value;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_post_meta')) {
+    function delete_post_meta(int $post_id, string $key): bool
+    {
+        unset($GLOBALS['__phpunit_post_meta'][$post_id][$key]);
+
+        return true;
     }
 }
 
@@ -63,6 +107,8 @@ final class ModernImagesTest extends TestCase
 
         $GLOBALS['__phpunit_attached_files'] = [];
         $GLOBALS['__phpunit_attachment_metadata'] = [];
+        $GLOBALS['__phpunit_post_meta'] = [];
+        $GLOBALS['__phpunit_fail_attachment_metadata_update'] = false;
         $GLOBALS['__phpunit_upload_dir'] = [
             'basedir' => $this->tmpDir,
             'baseurl' => 'https://example.test/wp-content/uploads',
@@ -147,6 +193,166 @@ final class ModernImagesTest extends TestCase
             strpos($picture, 'type="image/webp"'),
             strpos($picture, 'type="image/avif"')
         );
+    }
+
+    public function testMetadataUpdateQueuesModernImageTasksWithoutConvertingDuringUpload(): void
+    {
+        $source = $this->createJpeg('2026/07/source.jpg', 800, 500);
+        $this->createJpeg('2026/07/source-400x250.jpg', 400, 250);
+
+        $metadata = [
+            'file' => '2026/07/source.jpg',
+            'width' => 800,
+            'height' => 500,
+            'sizes' => [
+                'medium' => [
+                    'file' => 'source-400x250.jpg',
+                    'width' => 400,
+                    'height' => 250,
+                ],
+            ],
+        ];
+
+        $GLOBALS['__phpunit_attached_files'][30] = $source;
+
+        $result = amnesty_generate_modern_image_variants_on_metadata_update($metadata, 30);
+        $queue = get_post_meta(30, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, true);
+
+        self::assertSame($metadata, $result);
+        self::assertCount(4, $queue);
+        self::assertFileDoesNotExist($this->tmpDir . '/2026/07/source.avif');
+        self::assertFileDoesNotExist($this->tmpDir . '/2026/07/source.webp');
+    }
+
+    public function testWorkerProcessesOneTaskAndUpdatesMetadataBeforeRemovingIt(): void
+    {
+        $source = $this->createJpeg('2026/07/source.jpg', 800, 500);
+        $metadata = [
+            'file' => '2026/07/source.jpg',
+            'width' => 800,
+            'height' => 500,
+            'sizes' => [],
+        ];
+
+        $GLOBALS['__phpunit_attached_files'][31] = $source;
+        $GLOBALS['__phpunit_attachment_metadata'][31] = $metadata;
+
+        amnesty_enqueue_modern_image_variants(31, $metadata);
+        $stats = amnesty_process_modern_image_queue_for_attachment(31);
+
+        $stored = wp_get_attachment_metadata(31);
+        $queue = get_post_meta(31, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, true);
+
+        self::assertSame(1, $stats['processed']);
+        self::assertSame(1, $stats['updated']);
+        self::assertIsArray($stored);
+        self::assertCount(1, $stored[AMNESTY_MODERN_IMAGE_METADATA_KEY]['2026/07/source.jpg']);
+        self::assertCount(1, $queue);
+    }
+
+    public function testWorkerRegistersExistingSmallerVariantFromDiskWithoutRewritingIt(): void
+    {
+        $source = $this->createJpeg('2026/07/source.jpg', 800, 500);
+        $metadata = [
+            'file' => '2026/07/source.jpg',
+            'width' => 800,
+            'height' => 500,
+            'sizes' => [],
+        ];
+
+        $GLOBALS['__phpunit_attached_files'][32] = $source;
+        $GLOBALS['__phpunit_attachment_metadata'][32] = $metadata;
+
+        $webp = amnesty_generate_modern_image_variant(
+            $source,
+            '2026/07/source.jpg',
+            'image/webp',
+            [ 'extension' => 'webp', 'quality' => 82 ],
+            true
+        );
+
+        self::assertNotNull($webp);
+        $webpFile = $this->tmpDir . '/2026/07/source.webp';
+        touch($webpFile, time() - 100);
+        $mtime = filemtime($webpFile);
+
+        $taskKey = amnesty_modern_image_task_key('2026/07/source.jpg', 'image/webp');
+        update_post_meta(32, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, [
+            $taskKey => [
+                'relative_file' => '2026/07/source.jpg',
+                'mime_type' => 'image/webp',
+                'attempts' => 0,
+                'force' => false,
+            ],
+        ]);
+
+        $stats = amnesty_process_modern_image_queue_for_attachment(32);
+        $stored = wp_get_attachment_metadata(32);
+
+        self::assertSame(1, $stats['processed']);
+        self::assertSame(1, $stats['updated']);
+        self::assertSame($mtime, filemtime($webpFile));
+        self::assertIsArray($stored);
+        self::assertSame($webp['file'], $stored[AMNESTY_MODERN_IMAGE_METADATA_KEY]['2026/07/source.jpg']['image/webp']['file']);
+    }
+
+    public function testWorkerRespectsActiveLockAndResumesExpiredLock(): void
+    {
+        $source = $this->createJpeg('2026/07/source.jpg', 800, 500);
+        $metadata = [
+            'file' => '2026/07/source.jpg',
+            'width' => 800,
+            'height' => 500,
+            'sizes' => [],
+        ];
+
+        $GLOBALS['__phpunit_attached_files'][33] = $source;
+        $GLOBALS['__phpunit_attachment_metadata'][33] = $metadata;
+
+        amnesty_enqueue_modern_image_variants(33, $metadata);
+        update_post_meta(33, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY, time() + 300);
+
+        $locked = amnesty_process_modern_image_queue_for_attachment(33);
+        self::assertSame(1, $locked['locked']);
+        self::assertCount(2, get_post_meta(33, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, true));
+
+        update_post_meta(33, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY, time() - 1);
+
+        $resumed = amnesty_process_modern_image_queue_for_attachment(33);
+        self::assertSame(1, $resumed['processed']);
+        self::assertSame(1, $resumed['updated']);
+    }
+
+    public function testWorkerMovesTaskToFailedAfterMaxAttempts(): void
+    {
+        $source = $this->createJpeg('2026/07/source.jpg', 800, 500);
+        $metadata = [
+            'file' => '2026/07/source.jpg',
+            'width' => 800,
+            'height' => 500,
+            'sizes' => [],
+        ];
+        $taskKey = amnesty_modern_image_task_key('2026/07/missing.jpg', 'image/webp');
+
+        $GLOBALS['__phpunit_attached_files'][34] = $source;
+        $GLOBALS['__phpunit_attachment_metadata'][34] = $metadata;
+        update_post_meta(34, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, [
+            $taskKey => [
+                'relative_file' => '2026/07/missing.jpg',
+                'mime_type' => 'image/webp',
+                'attempts' => 0,
+                'force' => false,
+            ],
+        ]);
+
+        $stats = amnesty_process_modern_image_queue_for_attachment(34, 1);
+        $failedTasks = get_post_meta(34, AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY, true);
+
+        self::assertSame(1, $stats['processed']);
+        self::assertSame(1, $stats['failed']);
+        self::assertSame('', get_post_meta(34, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, true));
+        self::assertArrayHasKey($taskKey, $failedTasks);
+        self::assertSame('failed', get_post_meta(34, AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY, true));
     }
 
     private function createJpeg(string $relative, int $width, int $height): string

--- a/wp-content/themes/humanity-theme/includes/commands/modern-images.php
+++ b/wp-content/themes/humanity-theme/includes/commands/modern-images.php
@@ -10,7 +10,7 @@ if (! class_exists('Amnesty_Modern_Images_Command')) {
     class Amnesty_Modern_Images_Command
     {
         /**
-         * Generate missing AVIF/WebP variants for existing media.
+         * Queue missing AVIF/WebP variants for existing media.
          *
          * ## OPTIONS
          *
@@ -40,9 +40,8 @@ if (! class_exists('Amnesty_Modern_Images_Command')) {
             $ids = $this->get_attachment_ids($assoc_args, $batch_size);
 
             $processed = 0;
-            $updated = 0;
+            $queued = 0;
             $skipped = 0;
-            $saved_bytes = 0;
 
             foreach ($ids as $attachment_id) {
                 $processed++;
@@ -54,33 +53,72 @@ if (! class_exists('Amnesty_Modern_Images_Command')) {
                     continue;
                 }
 
-                $before = $metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY] ?? [];
-                $next_metadata = $dry_run ? $metadata : amnesty_generate_modern_image_variants($attachment_id, $metadata, $force);
-                $after = $next_metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY] ?? [];
-
-                if ($dry_run) {
-                    WP_CLI::log(sprintf('%d would be processed', $attachment_id));
+                $attached_file = get_attached_file($attachment_id);
+                if (! is_string($attached_file) || '' === $attached_file) {
+                    $skipped++;
+                    WP_CLI::log(sprintf('%d skipped: no attached file', $attachment_id));
                     continue;
                 }
 
-                if ($before === $after) {
+                $tasks = amnesty_modern_image_tasks($metadata, $attached_file, $force);
+
+                if ($dry_run) {
+                    WP_CLI::log(sprintf('%d would queue %d modern variant task(s)', $attachment_id, count($tasks)));
+                    continue;
+                }
+
+                if ($tasks === []) {
                     $skipped++;
                     continue;
                 }
 
-                wp_update_attachment_metadata($attachment_id, $next_metadata);
-                $updated++;
-                $saved_bytes += $this->saved_bytes($metadata, $next_metadata);
-                WP_CLI::log(sprintf('%d modern variants updated', $attachment_id));
+                $queued += amnesty_enqueue_modern_image_variants($attachment_id, $metadata, $force);
+                WP_CLI::log(sprintf('%d modern variant task(s) queued for attachment %d', count($tasks), $attachment_id));
             }
 
             WP_CLI::success(
                 sprintf(
-                    'Processed %d attachment(s), updated %d, skipped %d, generated about %s of transfer savings.',
+                    'Processed %d attachment(s), queued %d task(s), skipped %d.',
                     $processed,
-                    $updated,
-                    $skipped,
-                    size_format($saved_bytes)
+                    $queued,
+                    $skipped
+                )
+            );
+        }
+
+        /**
+         * Process queued AVIF/WebP variant tasks.
+         *
+         * ## OPTIONS
+         *
+         * [--limit=<number>]
+         * : Maximum number of variant tasks to process. Default: 20.
+         *
+         * [--time-limit=<seconds>]
+         * : Maximum runtime budget. Default: 45.
+         *
+         * [--max-attempts=<number>]
+         * : Number of conversion attempts before a task is marked failed. Default: 3.
+         *
+         * @param array<int,string> $args
+         * @param array<string,mixed> $assoc_args
+         */
+        public function process_modern_queue(array $args, array $assoc_args): void
+        {
+            $stats = amnesty_process_modern_image_queue(
+                max(1, (int) ($assoc_args['limit'] ?? 20)),
+                max(1, (int) ($assoc_args['time-limit'] ?? 45)),
+                max(1, (int) ($assoc_args['max-attempts'] ?? 3))
+            );
+
+            WP_CLI::success(
+                sprintf(
+                    'Processed %d task(s), updated %d, failed %d, skipped %d, locked %d.',
+                    $stats['processed'],
+                    $stats['updated'],
+                    $stats['failed'],
+                    $stats['skipped'],
+                    $stats['locked']
                 )
             );
         }
@@ -122,64 +160,6 @@ if (! class_exists('Amnesty_Modern_Images_Command')) {
             return $ids;
         }
 
-        /**
-         * @param array<string,mixed> $before
-         * @param array<string,mixed> $after
-         */
-        private function saved_bytes(array $before, array $after): int
-        {
-            $saved = 0;
-            $formats = $after[AMNESTY_MODERN_IMAGE_METADATA_KEY] ?? [];
-
-            if (! is_array($formats)) {
-                return 0;
-            }
-
-            foreach ($formats as $relative_file => $variants) {
-                if (! is_array($variants)) {
-                    continue;
-                }
-
-                $source_size = $this->source_filesize($relative_file, $before);
-                if ($source_size < 1) {
-                    continue;
-                }
-
-                foreach ($variants as $variant) {
-                    if (! is_array($variant) || empty($variant['filesize'])) {
-                        continue;
-                    }
-
-                    $saved += max(0, $source_size - (int) $variant['filesize']);
-                }
-            }
-
-            return $saved;
-        }
-
-        /**
-         * @param array<string,mixed> $metadata
-         */
-        private function source_filesize(string $relative_file, array $metadata): int
-        {
-            if (($metadata['file'] ?? '') === $relative_file && ! empty($metadata['filesize'])) {
-                return (int) $metadata['filesize'];
-            }
-
-            $dirname = amnesty_modern_image_relative_dir($metadata);
-            foreach (($metadata['sizes'] ?? []) as $size) {
-                if (! is_array($size) || empty($size['file'])) {
-                    continue;
-                }
-
-                $size_relative = ltrim(($dirname ? $dirname . '/' : '') . $size['file'], '/');
-                if ($size_relative === $relative_file && ! empty($size['filesize'])) {
-                    return (int) $size['filesize'];
-                }
-            }
-
-            return 0;
-        }
     }
 }
 

--- a/wp-content/themes/humanity-theme/includes/helpers/modern-images.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/modern-images.php
@@ -6,6 +6,22 @@ if (! defined('AMNESTY_MODERN_IMAGE_METADATA_KEY')) {
     define('AMNESTY_MODERN_IMAGE_METADATA_KEY', 'amnesty_modern_formats');
 }
 
+if (! defined('AMNESTY_MODERN_IMAGE_QUEUE_META_KEY')) {
+    define('AMNESTY_MODERN_IMAGE_QUEUE_META_KEY', '_amnesty_modern_image_queue');
+}
+
+if (! defined('AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY')) {
+    define('AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY', '_amnesty_modern_image_queue_status');
+}
+
+if (! defined('AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY')) {
+    define('AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY', '_amnesty_modern_image_queue_lock_until');
+}
+
+if (! defined('AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY')) {
+    define('AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY', '_amnesty_modern_image_failed_tasks');
+}
+
 if (! function_exists('amnesty_modern_image_formats')) {
     /**
      * @return array<string,array{extension:string,quality:int}>
@@ -86,6 +102,13 @@ if (! function_exists('amnesty_modern_image_candidates')) {
     }
 }
 
+if (! function_exists('amnesty_modern_image_task_key')) {
+    function amnesty_modern_image_task_key(string $relative_file, string $mime_type): string
+    {
+        return md5($relative_file . '|' . $mime_type);
+    }
+}
+
 if (! function_exists('amnesty_save_modern_image_with_gd')) {
     function amnesty_save_modern_image_with_gd(string $source_file, string $destination_file, string $mime_type, int $quality): bool
     {
@@ -113,6 +136,181 @@ if (! function_exists('amnesty_save_modern_image_with_gd')) {
         };
 
         return $saved;
+    }
+}
+
+if (! function_exists('amnesty_modern_image_tasks')) {
+    /**
+     * Build one conversion task per source image and target format.
+     *
+     * @param array<string,mixed> $metadata
+     * @return array<string,array{relative_file:string,mime_type:string,attempts:int,force:bool}>
+     */
+    function amnesty_modern_image_tasks(array $metadata, string $attached_file, bool $force = false): array
+    {
+        $tasks = [];
+        $modern_formats = is_array($metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY] ?? null)
+            ? $metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY]
+            : [];
+
+        foreach (amnesty_modern_image_candidates($metadata, $attached_file) as $relative_file => $_source_file) {
+            foreach (amnesty_modern_image_formats() as $mime_type => $_format) {
+                if (! $force && ! empty($modern_formats[$relative_file][$mime_type]['file'])) {
+                    continue;
+                }
+
+                $tasks[amnesty_modern_image_task_key($relative_file, $mime_type)] = [
+                    'relative_file' => $relative_file,
+                    'mime_type'     => $mime_type,
+                    'attempts'      => 0,
+                    'force'         => $force,
+                ];
+            }
+        }
+
+        return $tasks;
+    }
+}
+
+if (! function_exists('amnesty_normalize_modern_image_queue')) {
+    /**
+     * @return array<string,array{relative_file:string,mime_type:string,attempts:int,force:bool}>
+     */
+    function amnesty_normalize_modern_image_queue(mixed $queue): array
+    {
+        if (! is_array($queue)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($queue as $task) {
+            if (! is_array($task) || empty($task['relative_file']) || empty($task['mime_type'])) {
+                continue;
+            }
+
+            $relative_file = (string) $task['relative_file'];
+            $mime_type = (string) $task['mime_type'];
+            if (! isset(amnesty_modern_image_formats()[$mime_type])) {
+                continue;
+            }
+
+            $normalized[amnesty_modern_image_task_key($relative_file, $mime_type)] = [
+                'relative_file' => $relative_file,
+                'mime_type'     => $mime_type,
+                'attempts'      => max(0, (int) ($task['attempts'] ?? 0)),
+                'force'         => ! empty($task['force']),
+            ];
+        }
+
+        return $normalized;
+    }
+}
+
+if (! function_exists('amnesty_get_modern_image_queue')) {
+    /**
+     * @return array<string,array{relative_file:string,mime_type:string,attempts:int,force:bool}>
+     */
+    function amnesty_get_modern_image_queue(int $attachment_id): array
+    {
+        if (! function_exists('get_post_meta')) {
+            return [];
+        }
+
+        return amnesty_normalize_modern_image_queue(get_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, true));
+    }
+}
+
+if (! function_exists('amnesty_get_modern_image_failed_tasks')) {
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    function amnesty_get_modern_image_failed_tasks(int $attachment_id): array
+    {
+        if (! function_exists('get_post_meta')) {
+            return [];
+        }
+
+        $failed_tasks = get_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY, true);
+
+        return is_array($failed_tasks) ? $failed_tasks : [];
+    }
+}
+
+if (! function_exists('amnesty_update_modern_image_queue_status')) {
+    /**
+     * @param array<string,array{relative_file:string,mime_type:string,attempts:int,force:bool}> $queue
+     */
+    function amnesty_update_modern_image_queue_status(int $attachment_id, array $queue): void
+    {
+        if (! function_exists('update_post_meta') || ! function_exists('delete_post_meta')) {
+            return;
+        }
+
+        if ($queue !== []) {
+            update_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY, 'pending');
+            return;
+        }
+
+        delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY);
+        $failed_tasks = amnesty_get_modern_image_failed_tasks($attachment_id);
+        update_post_meta(
+            $attachment_id,
+            AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY,
+            $failed_tasks === [] ? 'complete' : 'failed'
+        );
+    }
+}
+
+if (! function_exists('amnesty_save_modern_image_queue')) {
+    /**
+     * @param array<string,array{relative_file:string,mime_type:string,attempts:int,force:bool}> $queue
+     */
+    function amnesty_save_modern_image_queue(int $attachment_id, array $queue): void
+    {
+        if (! function_exists('update_post_meta')) {
+            return;
+        }
+
+        if ($queue !== []) {
+            update_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_META_KEY, $queue);
+        }
+
+        amnesty_update_modern_image_queue_status($attachment_id, $queue);
+    }
+}
+
+if (! function_exists('amnesty_enqueue_modern_image_variants')) {
+    /**
+     * Queue missing modern variants without converting during the upload request.
+     *
+     * @param array<string,mixed> $metadata
+     */
+    function amnesty_enqueue_modern_image_variants(int $attachment_id, array $metadata, bool $force = false): int
+    {
+        if (! function_exists('get_attached_file')) {
+            return 0;
+        }
+
+        $attached_file = get_attached_file($attachment_id);
+        if (! is_string($attached_file) || '' === $attached_file) {
+            return 0;
+        }
+
+        $next_queue = amnesty_modern_image_tasks($metadata, $attached_file, $force);
+        if ($next_queue === []) {
+            amnesty_save_modern_image_queue($attachment_id, []);
+            return 0;
+        }
+
+        $queue = $force ? [] : amnesty_get_modern_image_queue($attachment_id);
+        $queue = array_replace($queue, $next_queue);
+        amnesty_save_modern_image_queue($attachment_id, $queue);
+
+        if ($force && function_exists('delete_post_meta')) {
+            delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY);
+        }
+
+        return count($next_queue);
     }
 }
 
@@ -247,7 +445,222 @@ if (! function_exists('amnesty_generate_modern_image_variants')) {
 if (! function_exists('amnesty_generate_modern_image_variants_on_metadata_update')) {
     function amnesty_generate_modern_image_variants_on_metadata_update(array $metadata, int $attachment_id): array
     {
-        return amnesty_generate_modern_image_variants($attachment_id, $metadata);
+        amnesty_enqueue_modern_image_variants($attachment_id, $metadata);
+
+        return $metadata;
+    }
+}
+
+if (! function_exists('amnesty_modern_image_source_for_task')) {
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    function amnesty_modern_image_source_for_task(array $metadata, string $attached_file, string $relative_file): string
+    {
+        $candidates = amnesty_modern_image_candidates($metadata, $attached_file);
+
+        return $candidates[$relative_file] ?? '';
+    }
+}
+
+if (! function_exists('amnesty_mark_modern_image_task_failed')) {
+    /**
+     * @param array{relative_file:string,mime_type:string,attempts:int,force:bool} $task
+     */
+    function amnesty_mark_modern_image_task_failed(int $attachment_id, string $task_key, array $task): void
+    {
+        if (! function_exists('update_post_meta')) {
+            return;
+        }
+
+        $failed_tasks = amnesty_get_modern_image_failed_tasks($attachment_id);
+        $failed_tasks[$task_key] = [
+            ...$task,
+            'failed_at' => time(),
+        ];
+
+        update_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_FAILED_TASKS_META_KEY, $failed_tasks);
+    }
+}
+
+if (! function_exists('amnesty_process_modern_image_queue_for_attachment')) {
+    /**
+     * Process at most one queued variant for an attachment.
+     *
+     * @return array{processed:int,updated:int,failed:int,skipped:int,locked:int}
+     */
+    function amnesty_process_modern_image_queue_for_attachment(int $attachment_id, int $max_attempts = 3, int $lock_ttl = 300): array
+    {
+        $stats = [
+            'processed' => 0,
+            'updated'   => 0,
+            'failed'    => 0,
+            'skipped'   => 0,
+            'locked'    => 0,
+        ];
+
+        if (! function_exists('get_post_meta') || ! function_exists('update_post_meta') || ! function_exists('delete_post_meta')) {
+            $stats['skipped']++;
+            return $stats;
+        }
+
+        $now = time();
+        $lock_until = (int) get_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY, true);
+        if ($lock_until > $now) {
+            $stats['locked']++;
+            return $stats;
+        }
+
+        $queue = amnesty_get_modern_image_queue($attachment_id);
+        if ($queue === []) {
+            delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY);
+            amnesty_update_modern_image_queue_status($attachment_id, []);
+            $stats['skipped']++;
+            return $stats;
+        }
+
+        update_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY, $now + max(60, $lock_ttl));
+        update_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_STATUS_META_KEY, 'processing');
+
+        $task_key = (string) array_key_first($queue);
+        $task = $queue[$task_key];
+
+        $metadata = function_exists('wp_get_attachment_metadata') ? wp_get_attachment_metadata($attachment_id) : false;
+        $attached_file = function_exists('get_attached_file') ? get_attached_file($attachment_id) : false;
+
+        if (! is_array($metadata) || ! is_string($attached_file) || '' === $attached_file) {
+            unset($queue[$task_key]);
+            amnesty_mark_modern_image_task_failed($attachment_id, $task_key, [ ...$task, 'attempts' => $task['attempts'] + 1 ]);
+            amnesty_save_modern_image_queue($attachment_id, $queue);
+            delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY);
+            $stats['processed']++;
+            $stats['failed']++;
+            return $stats;
+        }
+
+        $source_file = amnesty_modern_image_source_for_task($metadata, $attached_file, $task['relative_file']);
+        $format = amnesty_modern_image_formats()[$task['mime_type']] ?? null;
+        $variant = is_array($format)
+            ? amnesty_generate_modern_image_variant($source_file, $task['relative_file'], $task['mime_type'], $format, $task['force'])
+            : null;
+
+        $stats['processed']++;
+
+        if (null === $variant) {
+            $task['attempts']++;
+            if ($task['attempts'] >= max(1, $max_attempts)) {
+                unset($queue[$task_key]);
+                amnesty_mark_modern_image_task_failed($attachment_id, $task_key, $task);
+                $stats['failed']++;
+            } else {
+                $queue[$task_key] = $task;
+            }
+
+            amnesty_save_modern_image_queue($attachment_id, $queue);
+            delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY);
+            return $stats;
+        }
+
+        $modern_formats = is_array($metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY] ?? null)
+            ? $metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY]
+            : [];
+        $modern_formats[$task['relative_file']][$task['mime_type']] = $variant;
+        $metadata[AMNESTY_MODERN_IMAGE_METADATA_KEY] = $modern_formats;
+
+        $updated = function_exists('wp_update_attachment_metadata')
+            ? wp_update_attachment_metadata($attachment_id, $metadata)
+            : false;
+
+        if (false === $updated) {
+            $task['attempts']++;
+            $queue[$task_key] = $task;
+            amnesty_save_modern_image_queue($attachment_id, $queue);
+            delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY);
+            return $stats;
+        }
+
+        unset($queue[$task_key]);
+        amnesty_save_modern_image_queue($attachment_id, $queue);
+        delete_post_meta($attachment_id, AMNESTY_MODERN_IMAGE_QUEUE_LOCK_META_KEY);
+        $stats['updated']++;
+
+        return $stats;
+    }
+}
+
+if (! function_exists('amnesty_get_queued_modern_image_attachment_ids')) {
+    /**
+     * @return array<int,int>
+     */
+    function amnesty_get_queued_modern_image_attachment_ids(int $limit = 20): array
+    {
+        if (! function_exists('get_posts')) {
+            return [];
+        }
+
+        return array_map(
+            'absint',
+            get_posts([
+                'post_type'      => 'attachment',
+                'post_mime_type' => [ 'image/jpeg', 'image/png' ],
+                'post_status'    => 'inherit',
+                'posts_per_page' => max(1, $limit),
+                'fields'         => 'ids',
+                'orderby'        => 'ID',
+                'order'          => 'ASC',
+                'meta_query'     => [
+                    [
+                        'key'     => AMNESTY_MODERN_IMAGE_QUEUE_META_KEY,
+                        'compare' => 'EXISTS',
+                    ],
+                ],
+            ])
+        );
+    }
+}
+
+if (! function_exists('amnesty_process_modern_image_queue')) {
+    /**
+     * @return array{processed:int,updated:int,failed:int,skipped:int,locked:int}
+     */
+    function amnesty_process_modern_image_queue(int $limit = 20, int $time_limit = 45, int $max_attempts = 3): array
+    {
+        $stats = [
+            'processed' => 0,
+            'updated'   => 0,
+            'failed'    => 0,
+            'skipped'   => 0,
+            'locked'    => 0,
+        ];
+        $started_at = time();
+        $deadline = $started_at + max(1, $time_limit);
+        $lock_ttl = max(60, $time_limit + 60);
+        $limit = max(1, $limit);
+
+        while ($stats['processed'] < $limit && time() < $deadline) {
+            $ids = amnesty_get_queued_modern_image_attachment_ids($limit);
+            if ($ids === []) {
+                break;
+            }
+
+            $processed_before = $stats['processed'];
+            foreach ($ids as $attachment_id) {
+                if ($stats['processed'] >= $limit || time() >= $deadline) {
+                    break;
+                }
+
+                $attachment_stats = amnesty_process_modern_image_queue_for_attachment($attachment_id, $max_attempts, $lock_ttl);
+                foreach ($stats as $key => $_value) {
+                    $stats[$key] += $attachment_stats[$key];
+                }
+            }
+
+            if ($stats['processed'] === $processed_before) {
+                break;
+            }
+        }
+
+        return $stats;
     }
 }
 


### PR DESCRIPTION
## Résumé

- Remplace la conversion AVIF/WebP pendant l’upload par une file de tâches stockée en post meta.
- Ajoute un worker WP-CLI idempotent qui traite les variantes par petits lots avec lock, retries et tâches échouées.
- Branche une cron Clever Cloud pour exécuter régulièrement le worker.
- Étend les tests Media pour couvrir enqueue, traitement, reprise de lock, variantes déjà présentes et échecs.

## Contexte

La génération synchrone des variantes AVIF/WebP pouvait traiter jusqu’à 60 fichiers pendant la requête d’upload, provoquant un dépassement de la limite d’exécution PHP en production.

Ce correctif garde le rendu frontend existant : tant que les variantes modernes ne sont pas prêtes, les images JPG/PNG restent servies comme fallback.

## Tests

- `php -l wp-content/themes/humanity-theme/includes/helpers/modern-images.php`
- `php -l wp-content/themes/humanity-theme/includes/commands/modern-images.php`
- `php -l tests/Media/ModernImagesTest.php`
- `composer test -- --testsuite Media`
- `composer test`
- `vendor/bin/phpstan analyze --memory-limit=512M --no-progress`
- `composer cs`